### PR TITLE
Add describe-snapshot, clean up error handling

### DIFF
--- a/bin/cortex-agents.js
+++ b/bin/cortex-agents.js
@@ -32,6 +32,7 @@ const {
     StopAgentInstanceCommand,
     ListTriggersCommand,
     ListAgentSnapshotsCommand,
+    DescribeAgentSnapshotCommand,
     CreateAgentSnapshotCommand
 } = require('../src/commands/agents');
 
@@ -136,6 +137,22 @@ program
     .action((agentName, options) => {
         try {
             new ListAgentSnapshotsCommand(program).execute(agentName, options);
+            processed = true;
+        }
+        catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    });
+
+program
+    .command('describe-snapshot <snapshotId>')
+    .description('Describe agent snapshot')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
+    .action((snapshotId, options) => {
+        try {
+            new DescribeAgentSnapshotCommand(program).execute(snapshotId, options);
             processed = true;
         }
         catch (err) {

--- a/src/client/agents.js
+++ b/src/client/agents.js
@@ -79,8 +79,25 @@ module.exports = class Agents {
             });
     }
 
+    describeAgentSnapshot(token, snapshotId, environmentName) {
+        let endpoint = `${this.endpoint}/snapshots/${snapshotId}?deps=true`;
+        debug('describeAgentSnapshot(%s, %s) => %s', snapshotId, environmentName, endpoint);
+        if (environmentName) endpoint = `${endpoint}&environmentName=${environmentName}`;
+        return request
+            .get(endpoint)
+            .set('Authorization', `Bearer ${token}`)
+            .then((res) => {
+                if (res.ok) {
+                    return {success: true, result: res.body};
+                }
+                return {success: false, status: res.status, message: res.body};
+            })
+            .catch((err) => {
+                return constructError(err);
+            });
+    }
+
     createAgentSnapshot(token, snapshot) {
-        const agentName = snapshot.agentName;
         const endpoint = `${this.endpoint}/snapshots`;
         debug('getAgentSnapshot=> %s', endpoint);
         return request

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -254,7 +254,7 @@ module.exports.ListAgentSnapshotsCommand = class {
                     const tableSpec = [
                         { column: 'Snapshot ID', field: 'id', width: 30 },
                         { column: 'Title', field: 'title', width: 30 },
-                        { column: 'Description', field: 'description', width: 50 },
+                        { column: 'Agent Version', field: 'agentVersion', width: 15 },
                         { column: 'Environment', field: 'environmentName', width: 30 },
                         { column: 'Created On', field: 'createdAt', width: 26 }
                     ];
@@ -269,6 +269,32 @@ module.exports.ListAgentSnapshotsCommand = class {
             .catch((err) => {
                 printError(`Failed to list agent snapshots ${agentName}: ${err.status} ${err.message}`, options);
             });
+    }
+};
+
+
+module.exports.DescribeAgentSnapshotCommand = class {
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(snapshotId, options) {
+        const profile = loadProfile(options.profile);
+        const envName = options.environmentName;
+        debug('%s.describeAgentSnapshot(%s)', profile.name, snapshotId);
+
+        const agents = new Agents(profile.url);
+        agents.describeAgentSnapshot(profile.token, snapshotId, envName).then((response) => {
+            if (response.success) {
+                let result = filterObject(response.result, options);
+                printSuccess(JSON.stringify(result, null, 2), options);
+            }
+            else {
+                printError(`Failed to describe agent snapshot ${snapshotId}: ${response.message}`, options);
+            }
+        }).catch((err) => {
+            printError(`Failed to describe agent snapshot ${snapshotId}: ${err.status} ${err.message}`, options);
+        });
     }
 };
 

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -21,12 +21,17 @@ const debug = require('debug')('cortex:cli');
 const Table = require('cli-table');
 
 module.exports.constructError = function(error) {
-    const errorText = JSON.parse(error.response.text);
-    if (errorText.message) {
-        return {success: false, message: errorText.message, status: error.status};
-    } else {
-        return {success: false, message: JSON.stringify(errorText), status: error.status};
+    // fallback to text in message or standard error message
+    let errorText = error.response.text || error.message;
+
+    // if JSON was returned, look for either a message or error in it
+    try {
+        const resp = JSON.parse(error.response.text);
+        if (resp.message || resp.error) errorText = resp.message || resp.error;
+    } catch(e) {
+        // Guess it wasn't JSON!
     }
+    return {success: false, message: errorText, status: error.status};
 };
 
 module.exports.printSuccess = function(message, options) {


### PR DESCRIPTION
Made constructError utility more likely to produce something useful, particularly when response isn't JSON.

Added describe-snapshot subcommand, and tweaked list-snapshots to return agent version and not description (which is always empty).