### PR TITLE
Improve error messages and other cleanup to support Edge

### DIFF
--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -76,7 +76,6 @@ module.exports.ListAgentsCommand = class ListAgentsCommand {
                         { column: 'Name', field: 'name', width: 50 },
                         { column: 'Title', field: 'title', width: 25 },
                         { column: 'Description', field: 'description', width: 50 },
-                        { column: 'Environment', field: 'environmentId', width: 25 },
                         { column: 'Created On', field: 'createdAt', width: 26 }
                     ];
 

--- a/src/commands/environments.js
+++ b/src/commands/environments.js
@@ -45,11 +45,8 @@ module.exports.ListEnvironments = class ListEnvironments {
                 else {
                     let tableSpec = [
                         { column: 'Name', field: 'name', width: 25 },
-                        { column: 'Label', field: 'label', width: 25 },
-                        { column: 'Type', field: 'type', width: 15 },
-                        { column: 'Console Url', field: 'consoleUrl', width: 50 },
-                        { column: 'White List', field: 'whiteList', width: 50 },
-                        { column: 'Black List', field: 'blackList', width: 50 },
+                        { column: 'Title', field: 'title', width: 50 },
+                        { column: 'Region', field: 'regionRef', width: 25 }
                     ];
                     printTable(tableSpec, result);
                 }
@@ -190,7 +187,13 @@ module.exports.PromoteEnvironmentCommand = class PromoteEnvironmentCommand {
                 if (response.success) {
                     printSuccess(`Snapshot: \'${promObj.snapshotId}\' successfully promoted to environment:\'${promObj.environmentName}\'`, options);
                 } else {
-                    printError(`Failed to promote to environment: ${response.status} ${response.message}`, options);
+                    let errMsg = `Failed to promote to environment: ${response.status} ${response.message}\n`;
+                    if (response.details) {
+                        response.details.forEach(d =>
+                            errMsg = errMsg + `${d.resource} ${d.name} - ${d.error}\n`);
+                    }
+                    printError(errMsg, options);
+
                 }})
             .catch((err) => {
                 printError(`Failed to promote to environment: ${err.response.body.message}`, options);

--- a/src/commands/environments.js
+++ b/src/commands/environments.js
@@ -141,7 +141,7 @@ module.exports.ListInstancesCommand = class ListInstancesCommand {
                     let tableSpec = [
                         { column: 'Instance Id', field: 'id', width: 26 },
                         { column: 'Status', field: 'status', width: 15 },
-                        { column: 'Snapshot Id', field: 'snapshotId', width: 26 },
+                        { column: 'Snapshot Id', field: 'snapshotId', width: 40 },
                         { column: 'Agent Name', field: 'agentName', width: 50 },
                         { column: 'Agent Version', field: 'agentVersion', width: 15 },
                         { column: 'Environment', field: 'environmentName', width: 26 },

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -24,15 +24,17 @@ module.exports.constructError = function(error) {
     // fallback to text in message or standard error message
     let errResp = error.response;
     let errorText = (errResp && errResp.text) || error.message;
+    let details;
 
     // if JSON was returned, look for either a message or error in it
     try {
         const resp = errResp ? JSON.parse(errResp.text) : {};
         if (resp.message || resp.error) errorText = resp.message || resp.error;
+        details = resp.details;
     } catch(e) {
         // Guess it wasn't JSON!
     }
-    return {success: false, message: errorText, status: error.status || ''};
+    return {success: false, message: errorText, details, status: error.status || ''};
 };
 
 module.exports.printSuccess = function(message, options) {


### PR DESCRIPTION
* Report detailed errors on snapshot promotion.
* Drop confusing/invalid --environmentName parameter when listing types, agents or skills
* Drop invalid fields (label, blacklist, whitelist) from environments list, and add region
