### PR TITLE
Add backend compatibility check to all commands which use a profile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .dockerignore
-package.json
 README.md
 Dockerfile.c12e-ci.cortex-cli
 c12e-ci.yml

--- a/bin/cortex-accounts.js
+++ b/bin/cortex-accounts.js
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
 
 const {
     CreateGroupCommand,
@@ -41,7 +43,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--description [description]', 'Group description')
-    .action((groupName, options) => {
+    .action(withCompatibilityCheck((groupName, options) => {
         try {
             new CreateGroupCommand(program).execute(groupName, options);
             processed = true;
@@ -49,7 +51,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Add Members to Group
 program
@@ -57,7 +59,7 @@ program
     .description('Add members to group')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((groupName, members, options) => {
+    .action(withCompatibilityCheck((groupName, members, options) => {
         try {
             new AddMembersToGroupCommand(program).execute(groupName, members, options);
             processed = true;
@@ -65,7 +67,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Groups
 program
@@ -73,7 +75,7 @@ program
     .description('List groups')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListGroupsCommand(program).execute(options);
             processed = true;
@@ -81,7 +83,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Group
 program
@@ -89,7 +91,7 @@ program
     .description('Describe a group')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((groupName, options) => {
+    .action(withCompatibilityCheck((groupName, options) => {
         try {
             new DescribeGroupCommand(program).execute(groupName, options);
             processed = true;
@@ -97,7 +99,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Delete Group
 program
@@ -105,7 +107,7 @@ program
     .description('Delete a group')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((groupName, options) => {
+    .action(withCompatibilityCheck((groupName, options) => {
         try {
             new DeleteGroupCommand(program).execute(groupName, options);
             processed = true;
@@ -113,7 +115,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Remove Members From Group
 program
@@ -121,7 +123,7 @@ program
     .description('Remove members from a group')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((groupName, members, options) => {
+    .action(withCompatibilityCheck((groupName, members, options) => {
         try {
             new RemoveMembersFromGroupCommand(program).execute(groupName, members, options);
             processed = true;
@@ -129,7 +131,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Register Resource
 program
@@ -139,7 +141,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--description [description]', 'Resource description')
     .option('--access [access]', 'Access level of resource [read/write/admin/execute]')
-    .action((resourceName, options) => {
+    .action(withCompatibilityCheck((resourceName, options) => {
         try {
             new RegisterResourceCommand(program).execute(resourceName, options);
             processed = true;
@@ -147,7 +149,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Grant Group Access To Resource
 program
@@ -155,7 +157,7 @@ program
     .description('Grant group access to a resource')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((resourceId, groupName, options) => {
+    .action(withCompatibilityCheck((resourceId, groupName, options) => {
         try {
             new GrantGroupAccessToResourceCommand(program).execute(resourceId, groupName, options);
             processed = true;
@@ -163,7 +165,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -16,9 +16,12 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
 const {
     ListActionsCommand,
     DescribeActionCommand,
@@ -38,7 +41,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListActionsCommand(program).execute(options);
             processed = true;
@@ -46,7 +49,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Action
 program
@@ -56,7 +59,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
     .option('-d, --download', 'Download code binary in response')
-    .action((actionName, options) => {
+    .action(withCompatibilityCheck((actionName, options) => {
         try {
             new DescribeActionCommand(program).execute(actionName, options);
             processed = true;
@@ -64,7 +67,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Delete Action
 program
@@ -74,7 +77,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
     .option('--actionType [actionType]', 'Type of action')
-    .action((actionName, options) => {
+    .action(withCompatibilityCheck((actionName, options) => {
         try {
             new DeleteActionCommand(program).execute(actionName, options);
             processed = true;
@@ -82,7 +85,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Invoke Action
 program
@@ -96,7 +99,7 @@ program
     .option('--actionType [actionType]', 'Type of action')
     .option('--path [path]', 'Path to the daemon service url being invoked', '')
     .option('--method [method]', 'HTTP method')                                         // GET, POST ...
-    .action((actionName, options) => {
+    .action(withCompatibilityCheck((actionName, options) => {
         try {
             new InvokeActionCommand(program).execute(actionName, options);
             processed = true;
@@ -104,7 +107,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Deploy Action
 program
@@ -121,7 +124,7 @@ program
     .option('--port [port]', 'Docker port')                  //'9091'
     .option('--environment [environment]', 'Environment')
     .option('--cmd [cmd]', 'Command to be executed')    //'["--daemon"]'
-    .action((actionName, options) => {
+    .action(withCompatibilityCheck((actionName, options) => {
         try {
             if (!options.kind && !options.docker) {
                 throw new Error('--kind [kind] or --docker [image] required');
@@ -137,7 +140,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-agents.js
+++ b/bin/cortex-agents.js
@@ -16,9 +16,12 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
 const {
     SaveAgentCommand,
     ListAgentsCommand,
@@ -46,7 +49,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
-    .action((agentDefinition, options) => {
+    .action(withCompatibilityCheck((agentDefinition, options) => {
         try {
             new SaveAgentCommand(program).execute(agentDefinition, options);
             processed = true;
@@ -54,7 +57,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Agents
 program
@@ -64,7 +67,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListAgentsCommand(program).execute(options);
             processed = true;
@@ -72,7 +75,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Agent
 program
@@ -82,7 +85,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
     .option('--versions', 'To get list of versions of an agent')
-    .action((agentName, options) => {
+    .action(withCompatibilityCheck((agentName, options) => {
         try {
             new DescribeAgentCommand(program).execute(agentName, options);
             processed = true;
@@ -90,7 +93,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Invoke Agent Service
 program
@@ -100,7 +103,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--params [params]', 'JSON params to send to the action')
     .option('--params-file [paramsFile]', 'A file containing either JSON or YAML formatted params')
-    .action((agentName, serviceName, options) => {
+    .action(withCompatibilityCheck((agentName, serviceName, options) => {
         try {
             new InvokeAgentServiceCommand(program).execute(agentName, serviceName, options);
             processed = true;
@@ -108,7 +111,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Get Agent Service Activation
 program
@@ -136,7 +139,7 @@ program
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((agentName, options) => {
+    .action(withCompatibilityCheck((agentName, options) => {
         try {
             new ListAgentSnapshotsCommand(program).execute(agentName, options);
             processed = true;
@@ -144,7 +147,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 program
     .command('describe-snapshot <snapshotId>')
@@ -152,7 +155,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
-    .action((snapshotId, options) => {
+    .action(withCompatibilityCheck((snapshotId, options) => {
         try {
             new DescribeAgentSnapshotCommand(program).execute(snapshotId, options);
             processed = true;
@@ -160,7 +163,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Create Agent Snapshot
 program
@@ -171,7 +174,7 @@ program
     .option('--agentName [name[:version]]', 'The name of the agent to snapshot')
     .option('--title [title]', 'A descriptive title for the snapshot')
 
-    .action((snapshotDefinition, options) => {
+    .action(withCompatibilityCheck((snapshotDefinition, options) => {
         try {
             new CreateAgentSnapshotCommand(program).execute(snapshotDefinition, options);
             processed = true;
@@ -179,7 +182,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 //List agent instances
@@ -191,7 +194,7 @@ program
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((agentName, options) => {
+    .action(withCompatibilityCheck((agentName, options) => {
         try {
             new ListAgentInstancesCommand(program).execute(agentName, options);
             processed = true;
@@ -199,7 +202,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Create agent instances
 program
@@ -210,7 +213,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--snapshotId [snapshotId]', 'The name of the agent to snapshot')
 
-    .action((instanceDefinition, options) => {
+    .action(withCompatibilityCheck((instanceDefinition, options) => {
         try {
             new CreateAgentInstanceCommand(program).execute(instanceDefinition, options);
             processed = true;
@@ -218,7 +221,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Get agent instance
 program
@@ -227,7 +230,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
-    .action((instanceId, options) => {
+    .action(withCompatibilityCheck((instanceId, options) => {
         try {
             new GetAgentInstanceCommand(program).execute(instanceId, options);
             processed = true;
@@ -235,7 +238,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Delete agent instance
 program
@@ -243,7 +246,7 @@ program
     .description('Delete agent instance')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((instanceId, options) => {
+    .action(withCompatibilityCheck((instanceId, options) => {
         try {
             new DeleteAgentInstanceCommand(program).execute(instanceId, options);
             processed = true;
@@ -251,7 +254,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //Stop agent instance
 program
@@ -259,7 +262,7 @@ program
     .description('Stop agent instance')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((instanceId, options) => {
+    .action(withCompatibilityCheck((instanceId, options) => {
         try {
             new StopAgentInstanceCommand(program).execute(instanceId, options);
             processed = true;
@@ -267,7 +270,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 //List triggers
 program
@@ -275,7 +278,7 @@ program
     .description('List of triggers for the current tenant')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListTriggersCommand(program).execute(options);
             processed = true;
@@ -283,7 +286,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);

--- a/bin/cortex-configure.js
+++ b/bin/cortex-configure.js
@@ -17,7 +17,14 @@
  */
 
 const program = require('commander');
-const { ConfigureCommand, DescribeProfileCommand, ListProfilesCommand, SetProfileCommand } = require('../src/commands/configure');
+
+const {
+    ConfigureCommand,
+    DescribeProfileCommand,
+    ListProfilesCommand,
+    SetProfileCommand
+} = require('../src/commands/configure');
+
 program.description('Configure the Cortex CLI');
 
 let cmd = undefined;

--- a/bin/cortex-connections.js
+++ b/bin/cortex-connections.js
@@ -16,11 +16,20 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListConnections, SaveConnectionCommand, DescribeConnectionCommand, TestConnectionCommand,
-    ListConnectionsTypes, GenerateConnectionCommand } = require('../src/commands/connections');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListConnections,
+    SaveConnectionCommand,
+    DescribeConnectionCommand,
+    TestConnectionCommand,
+    ListConnectionsTypes,
+    GenerateConnectionCommand
+} = require('../src/commands/connections');
 
 let processed = false;
 program.description('Work with Cortex Connections');
@@ -34,7 +43,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListConnections(program).execute(options);
             processed = true;
@@ -42,7 +51,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Save Connections
 program
@@ -51,7 +60,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
-    .action((connDefinition, options) => {
+    .action(withCompatibilityCheck((connDefinition, options) => {
         try {
             new SaveConnectionCommand(program).execute(connDefinition, options);
             processed = true;
@@ -59,7 +68,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Connection
 program
@@ -68,7 +77,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((connectionName, options) => {
+    .action(withCompatibilityCheck((connectionName, options) => {
         try {
             new DescribeConnectionCommand(program).execute(connectionName, options);
             processed = true;
@@ -76,7 +85,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Test Connections
 program
@@ -85,7 +94,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
-    .action((connDefinition, options) => {
+    .action(withCompatibilityCheck((connDefinition, options) => {
         try {
             new TestConnectionCommand(program).execute(connDefinition, options);
             processed = true;
@@ -93,7 +102,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Connections Types
 program
@@ -103,7 +112,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListConnectionsTypes(program).execute(options);
             processed = true;
@@ -111,7 +120,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 // Generate Connections
@@ -119,8 +128,7 @@ program
     .command('generate')
     .description('Generates the structure of the connection payload')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
-    .option('--profile [profile]', 'The profile to use', 'default')
-    .action((options) => {
+    .action((options) => { // deliberately not using withCompatibilityCheck()
         try {
             new GenerateConnectionCommand(program).execute(options);
             processed = true;

--- a/bin/cortex-content.js
+++ b/bin/cortex-content.js
@@ -16,10 +16,18 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListContent, UploadContent, DeleteContent, DownloadContent } = require('../src/commands/content');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListContent,
+    UploadContent,
+    DeleteContent,
+    DownloadContent
+} = require('../src/commands/content');
 
 let processed = false;
 program.description('Work with Cortex Contents');
@@ -33,7 +41,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListContent(program).execute(options);
             processed = true;
@@ -41,7 +49,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Upload Content
 program
@@ -50,7 +58,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--secure', 'Uploads the content securely to the Cortex Vault. Use this option for keytab files or content that contains sensitive information that is required during Runtime. Take note of the contentKey you give to this content for future reference.')
-    .action((contentKey, filePath, options) => {
+    .action(withCompatibilityCheck((contentKey, filePath, options) => {
         try {
             new UploadContent(program).execute(contentKey, filePath, options);
             processed = true;
@@ -58,7 +66,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Delete Content
 program
@@ -66,7 +74,7 @@ program
     .description('Delete content')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((contentKey, options) => {
+    .action(withCompatibilityCheck((contentKey, options) => {
         try {
             new DeleteContent(program).execute(contentKey, options);
             processed = true;
@@ -74,7 +82,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Download Content
 program
@@ -83,7 +91,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--secure', 'Downloads the content securely from the Cortex Vault.')
-    .action((contentKey, options) => {
+    .action(withCompatibilityCheck((contentKey, options) => {
         try {
             new DownloadContent(program).execute(contentKey, options);
             processed = true;
@@ -91,7 +99,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);

--- a/bin/cortex-datasets.js
+++ b/bin/cortex-datasets.js
@@ -16,11 +16,20 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListDatasets, SaveDatasetsCommand, DescribeDatasetCommand, GetDataframeCommand,
-    StreamDatasetCommand, GenerateDatasetCommand } = require('../src/commands/datasets');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListDatasets,
+    SaveDatasetsCommand,
+    DescribeDatasetCommand,
+    GetDataframeCommand,
+    StreamDatasetCommand,
+    GenerateDatasetCommand
+} = require('../src/commands/datasets');
 
 let processed = false;
 program.description('Work with Cortex Connections');
@@ -34,7 +43,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using detailed JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListDatasets(program).execute(options);
             processed = true;
@@ -42,7 +51,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Save Dataset
 program
@@ -51,7 +60,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for dataset file definition format')
-    .action((datasetDef, options) => {
+    .action(withCompatibilityCheck((datasetDef, options) => {
         try {
             new SaveDatasetsCommand(program).execute(datasetDef, options);
             processed = true;
@@ -59,7 +68,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Dataset
 program
@@ -68,7 +77,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((datasetName, options) => {
+    .action(withCompatibilityCheck((datasetName, options) => {
         try {
             new DescribeDatasetCommand(program).execute(datasetName, options);
             processed = true;
@@ -76,7 +85,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Get Dataframe
 program
@@ -84,7 +93,7 @@ program
     .description('Get dataset in dataframe format')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((datasetName, options) => {
+    .action(withCompatibilityCheck((datasetName, options) => {
         try {
             new GetDataframeCommand(program).execute(datasetName, options);
             processed = true;
@@ -92,7 +101,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Get Stream
 program
@@ -100,7 +109,7 @@ program
     .description('Stream dataset content')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((datasetName, options) => {
+    .action(withCompatibilityCheck((datasetName, options) => {
         try {
             new StreamDatasetCommand(program).execute(datasetName, options);
             processed = true;
@@ -108,14 +117,14 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 program
     .command('generate')
     .description('Generates the structure and top level build script for a dataset')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use', 'default')
-    .action((options) => {
+    .action((options) => {  // deliberately not using withCompatibilityCheck()
         try {
             new GenerateDatasetCommand(program).execute(options);
         }

--- a/bin/cortex-environments.js
+++ b/bin/cortex-environments.js
@@ -16,11 +16,19 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListEnvironments, SaveEnvironmentCommand, PromoteEnvironmentCommand,
-    DescribeEnvironmentCommand, ListInstancesCommand } = require('../src/commands/environments');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListEnvironments,
+    SaveEnvironmentCommand,
+    PromoteEnvironmentCommand,
+    DescribeEnvironmentCommand,
+    ListInstancesCommand
+} = require('../src/commands/environments');
 
 let processed = false;
 program.description('Work with Cortex Environments');
@@ -34,7 +42,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListEnvironments(program).execute(options);
             processed = true;
@@ -42,7 +50,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Save Environement
 program
@@ -51,7 +59,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for environment definition format')
-    .action((envDefinition, options) => {
+    .action(withCompatibilityCheck((envDefinition, options) => {
         try {
             new SaveEnvironmentCommand(program).execute(envDefinition, options);
             processed = true;
@@ -59,7 +67,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Promote Environment
 program
@@ -70,7 +78,7 @@ program
     .option('-y, --yaml', 'Use YAML for environment definition format')
     .option('--snapshotId [snapshotId]', 'SnapshotID to promote')
     .option('--environmentName [environmentName]', 'Environment to promote snapshotId to')
-    .action((promotionDefinition, options) => {
+    .action(withCompatibilityCheck((promotionDefinition, options) => {
         try {
             new PromoteEnvironmentCommand(program).execute(promotionDefinition, options);
             processed = true;
@@ -78,7 +86,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Environment
 program
@@ -87,7 +95,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((environmentName, options) => {
+    .action(withCompatibilityCheck((environmentName, options) => {
         try {
             new DescribeEnvironmentCommand(program).execute(environmentName, options);
             processed = true;
@@ -95,7 +103,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 
@@ -107,7 +115,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((environmentName, options) => {
+    .action(withCompatibilityCheck((environmentName, options) => {
         try {
             new ListInstancesCommand(program).execute(environmentName || 'cortex/default', options);
             processed = true;
@@ -115,7 +123,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 program.parse(process.argv);

--- a/bin/cortex-jobs.js
+++ b/bin/cortex-jobs.js
@@ -16,10 +16,18 @@
 * limitations under the License.
 */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListJobs, JobStatus, DescribeJob, SaveJob } = require('../src/commands/jobs');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListJobs,
+    JobStatus,
+    DescribeJob,
+    SaveJob
+} = require('../src/commands/jobs');
 
 let processed = false;
 program.description('Work with Cortex Jobs');
@@ -33,7 +41,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListJobs(program).execute(options);
             processed = true;
@@ -41,7 +49,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Job
 program
@@ -50,7 +58,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
-    .action((jobDefinition, options) => {
+    .action(withCompatibilityCheck((jobDefinition, options) => {
         try {
             new DescribeJob(program).execute(jobDefinition, options);
             processed = true;
@@ -58,7 +66,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Get Job Status
 program
@@ -67,7 +75,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
-    .action((jobDefinition, options) => {
+    .action(withCompatibilityCheck((jobDefinition, options) => {
         try {
             new JobStatus(program).execute(jobDefinition, options);
             processed = true;
@@ -75,7 +83,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 // Save Job
@@ -85,7 +93,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for job definition format')
-    .action((jobDefinition, options) => {
+    .action(withCompatibilityCheck((jobDefinition, options) => {
         try {
             new SaveJob(program).execute(jobDefinition, options);
             processed = true;
@@ -93,7 +101,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-processors.js
+++ b/bin/cortex-processors.js
@@ -16,9 +16,12 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
 const { 
     ListRuntimesCommand, 
     ListRuntimeTypesCommand, 
@@ -39,7 +42,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListRuntimeTypesCommand(program).execute(options);
             processed = true;
@@ -47,7 +50,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Processor Runtimes
 program
@@ -57,7 +60,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListRuntimesCommand(program).execute(options);
             processed = true;
@@ -65,7 +68,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Processor Runtime
 program
@@ -74,7 +77,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((runtimeName, options) => {
+    .action(withCompatibilityCheck((runtimeName, options) => {
         try {
             new DescribeRuntimeCommand(program).execute(runtimeName, options);
             processed = true;
@@ -82,7 +85,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Delete Processor Runtime
 program
@@ -90,7 +93,7 @@ program
     .description('Delete a processor runtime')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((runtimeName, options) => {
+    .action(withCompatibilityCheck((runtimeName, options) => {
         try {
             new DeleteRuntimeCommand(program).execute(runtimeName, options);
             processed = true;
@@ -98,7 +101,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Actions
 program
@@ -108,7 +111,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((runtimeName, options) => {
+    .action(withCompatibilityCheck((runtimeName, options) => {
         try {
             new ListActionsCommand(program).execute(runtimeName, options);
             processed = true;
@@ -116,7 +119,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Invoke Action
 program
@@ -127,7 +130,7 @@ program
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
     .option('--params [params]', 'JSON params to send to the action')
     .option('--params-file [paramsFile]', 'A file containing either JSON or YAML formatted params')
-    .action((runtimeName, actionId, options) => {
+    .action(withCompatibilityCheck((runtimeName, actionId, options) => {
         try {
             new InvokeActionCommand(program).execute(runtimeName, actionId, options);
             processed = true;
@@ -135,7 +138,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-project.js
+++ b/bin/cortex-project.js
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const {
-    GenerateProjectCommand
-} = require('../src/commands/project');
+const program = require('commander');
+
+const helper = require('./utils.js');
+
+const { GenerateProjectCommand } = require('../src/commands/project');
 
 let processed = false;
 program.description('Work with a related collection of Cortex contributions');
@@ -31,7 +31,6 @@ program
     .command('generate')
     .description('Generates the structure and top level build script for a project')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
-    .option('--profile [profile]', 'The profile to use')
     .action((options) => {
         try {
             new GenerateProjectCommand(program).execute(options);

--- a/bin/cortex-skills.js
+++ b/bin/cortex-skills.js
@@ -16,10 +16,18 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { SaveSkillCommand, ListSkillsCommand, DescribeSkillCommand, GenerateSkillCommand } = require('../src/commands/skills');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    SaveSkillCommand,
+    ListSkillsCommand,
+    DescribeSkillCommand,
+    GenerateSkillCommand
+} = require('../src/commands/skills');
 
 let processed = false;
 program.description('Work with Cortex Skills');
@@ -31,7 +39,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for skill definition format')
-    .action((skillDefinition, options) => {
+    .action(withCompatibilityCheck((skillDefinition, options) => {
         try {
             new SaveSkillCommand(program).execute(skillDefinition, options);
             processed = true;
@@ -39,7 +47,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Skills
 program
@@ -49,7 +57,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListSkillsCommand(program).execute(options);
             processed = true;
@@ -57,7 +65,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Skill
 program
@@ -66,7 +74,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((skillName, options) => {
+    .action(withCompatibilityCheck((skillName, options) => {
         try {
             new DescribeSkillCommand(program).execute(skillName, options);
             processed = true;
@@ -74,14 +82,13 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 program
     .command('generate')
     .description('Generates the structure and top level build script for a skill')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
-    .option('--profile [profile]', 'The profile to use', 'default')
-    .action((options) => {
+    .action((options) => { // deliberately not using withCompatibilityCheck()
         try {
             new GenerateSkillCommand(program).execute(options);
             processed = true;

--- a/bin/cortex-tasks.js
+++ b/bin/cortex-tasks.js
@@ -16,10 +16,18 @@
 * limitations under the License.
 */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { ListTasks, TaskLogs, CancelTask, DescribeTask } = require('../src/commands/tasks');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    ListTasks,
+    TaskLogs,
+    CancelTask,
+    DescribeTask
+} = require('../src/commands/tasks');
 
 let processed = false;
 program.description('Work with Cortex Jobs');
@@ -33,7 +41,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((jobId, options) => {
+    .action(withCompatibilityCheck((jobId, options) => {
         try {
             new ListTasks(program).execute(jobId, options);
             processed = true;
@@ -41,7 +49,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Get Tasks logs
 program
@@ -51,7 +59,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((jobId, taskId, options) => {
+    .action(withCompatibilityCheck((jobId, taskId, options) => {
         try {
             new TaskLogs(program).execute(jobId, taskId, options);
             processed = true;
@@ -59,7 +67,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Cancel task
 program
@@ -69,7 +77,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('-m, --message <message>', 'Cancellation message')
-    .action((jobId, taskId, options) => {
+    .action(withCompatibilityCheck((jobId, taskId, options) => {
         try {
             new CancelTask(program).execute(jobId, taskId, options);
             processed = true;
@@ -77,7 +85,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe task
 program
@@ -87,7 +95,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
-    .action((jobId, taskId, options) => {
+    .action(withCompatibilityCheck((jobId, taskId, options) => {
         try {
             new DescribeTask(program).execute(jobId, taskId, options);
             processed = true;
@@ -95,7 +103,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-types.js
+++ b/bin/cortex-types.js
@@ -16,10 +16,17 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
-const { SaveTypeCommand, ListTypesCommand, DescribeTypeCommand } = require('../src/commands/types');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
+
+const {
+    SaveTypeCommand,
+    ListTypesCommand,
+    DescribeTypeCommand
+} = require('../src/commands/types');
 
 let processed = false;
 program.description('Work with Cortex Types');
@@ -31,7 +38,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for type definition format')
-    .action((typeDefinition, options) => {
+    .action(withCompatibilityCheck((typeDefinition, options) => {
         try {
             new SaveTypeCommand(program).execute(typeDefinition, options);
             processed = true;
@@ -39,7 +46,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // List Types
 program
@@ -49,7 +56,7 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListTypesCommand(program).execute(options);
             processed = true;
@@ -57,7 +64,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Describe Type
 program
@@ -66,7 +73,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((typeName, options) => {
+    .action(withCompatibilityCheck((typeName, options) => {
         try {
             new DescribeTypeCommand(program).execute(typeName, options);
             processed = true;
@@ -74,7 +81,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/bin/cortex-variables.js
+++ b/bin/cortex-variables.js
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 
-const helper = require('./utils.js');
-const program = require('commander');
 const chalk = require('chalk');
+const program = require('commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+const helper = require('./utils.js');
 
 const {
     ListVariablesCommand,
@@ -35,7 +37,7 @@ program
     .description('List secure variable keys')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((options) => {
+    .action(withCompatibilityCheck((options) => {
         try {
             new ListVariablesCommand(program).execute(options);
             processed = true;
@@ -43,7 +45,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Read Secure Variable Value
 program
@@ -51,7 +53,7 @@ program
     .description('Retrieve the value stored for the given variable key.')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .action((keyName, options) => {
+    .action(withCompatibilityCheck((keyName, options) => {
         try {
             new ReadVariableCommand(program).execute(keyName, options);
             processed = true;
@@ -59,7 +61,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 // Write Secure Variable Value
 program
@@ -69,7 +71,7 @@ program
     .option('--data [data]', 'JSON value to save')
     .option('--data-file [dataFile]', 'A file containing either JSON or YAML formatted value to save')
     .option('--profile [profile]', 'The profile to use')
-    .action((keyName, value, options) => {
+    .action(withCompatibilityCheck((keyName, value, options) => {
         try {
             new WriteVariableCommand(program).execute(keyName, value, options);
             processed = true;
@@ -77,7 +79,7 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 process.env.DOC && require('../src/commands/utils').exportDoc(program);
 

--- a/package.json
+++ b/package.json
@@ -26,22 +26,31 @@
   "homepage": "https://github.com/CognitiveScale/cortex-cli",
   "dependencies": {
     "@c12e/generator-cortex": "0.3.10",
+    "boxen": "1.3.0",
     "chalk": "2.3.0",
     "cli-table": "0.3.1",
     "co": "4.6.0",
     "co-prompt": "1.0.0",
-    "commander": "2.12.2",
+    "commander": "2.16.0",
     "debug": "3.1.0",
     "event-stream": "3.3.4",
+    "find-package-json": "1.1.0",
+    "is-installed-globally": "0.1.0",
     "jmespath": "0.15.0",
     "joi": "13.1.0",
     "js-yaml": "3.10.0",
     "lodash": "4.17.10",
+    "npm-registry-fetch": "3.2.0",
+    "semver": "5.5.0",
     "superagent": "3.8.2",
     "uuid": "3.2.1",
     "yeoman-environment": "2.0.5"
   },
   "devDependencies": {
-    "mocha": "5.0.0"
+    "chai": "4.1.2",
+    "chai-as-promised": "7.1.1",
+    "mocha": "5.2.0",
+    "rewire": "4.0.1",
+    "superagent-mocker": "0.5.2"
   }
 }

--- a/src/commands/connections.js
+++ b/src/commands/connections.js
@@ -293,7 +293,7 @@ module.exports.GenerateConnectionCommand = class GenerateConnectionCommand {
     }
 
     execute(options) {
-        debug('%s.generateConnection()', options.profile);
+        debug('%s.generateConnection()');
         const yenv = yeoman.createEnv();
         yenv.lookup(()=>{
             yenv.run('@c12e/cortex:connections',

--- a/src/commands/skills.js
+++ b/src/commands/skills.js
@@ -122,7 +122,7 @@ module.exports.GenerateSkillCommand = class GenerateSkillCommand {
     }
 
     execute(options) {
-        debug('%s.generateSkill()', options.profile);
+        debug('%s.generateSkill()');
         const yenv = yeoman.createEnv();
         yenv.lookup(()=>{
             yenv.run('@c12e/cortex:skill',

--- a/src/compatibility.js
+++ b/src/compatibility.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const boxen = require('boxen');
+const chalk = require('chalk');
+const debug = require('debug')('cortex:cli');
+const filter = require('lodash/fp/filter');
+const findPackageJson = require('find-package-json');
+const getOr = require('lodash/fp/getOr');
+const isInstalledGlobally = require('is-installed-globally');
+const keys = require('lodash/fp/keys');
+const last = require('lodash/fp/last');
+const npmFetch = require('npm-registry-fetch');
+const request = require('superagent');
+const semver = require('semver');
+
+const { loadProfile } = require('./config');
+const { printError } = require('../src/commands/utils');
+
+const pkg = findPackageJson(__dirname).next().value;
+
+function getAvailableVersions(name) {
+    return npmFetch
+        .json(pkg.name)
+        .then(manifest => keys(getOr({}, 'versions', manifest)))
+        .then(versions => versions.sort(semver.compare))
+        .catch((error) => {
+            throw new Error('Unable to determine CLI available versions');
+        });
+}
+
+function getRequiredVersion(profile) {
+    const endpoint = `${profile.url}/v3/catalog/compatibility/applications/cortex-cli`;
+    return request
+        .get(endpoint)
+        .set('Authorization', `Bearer ${profile.token}`)
+        .set('x-cortex-proxy-notify', true)
+        .then((res) => {
+            if (!res.ok) {  throw new Error('Unable to fetch compatibility'); }
+            const { semver } = res.body;
+            return semver;
+        });
+}
+
+function notifyUpdate({ required = false, current, latest }) {
+    const opts = {
+        padding: 1,
+        margin: 1,
+        align: 'center',
+        borderColor: 'yellow',
+        borderStyle: 'round'
+    };
+
+    const message =
+        `Update ${required ? chalk.bold('required') : 'available'} ` +
+        chalk.dim(current) +
+        chalk.reset(' → ') +
+        chalk.green(latest) +
+        '\nRun ' +
+        chalk.cyan(`npm i ${isInstalledGlobally ? '-g' : ''}${pkg.name}@${latest}`) +
+        ' to update';
+
+    console.log(boxen(message, opts));
+}
+
+function upgradeAvailable(args) {
+    process.on('exit', () => {
+        notifyUpdate(args);
+    });
+}
+
+function upgradeRequired(args) {
+    notifyUpdate({ required: true, ...args });
+    process.exit(-1);
+}
+
+function getCompatibility(profile) {
+    debug('getCompatibility => %s', this.endpoint);
+    return Promise
+        .all([
+            getAvailableVersions(pkg.name),
+            getRequiredVersion(profile)
+        ])
+        .then(([versions, requirements]) => {
+            const compatibleVersions = filter(v => semver.satisfies(v, requirements), versions);
+
+            const { version: current } = pkg;
+            const latest = last(compatibleVersions);
+            const satisfied = semver.satisfies(pkg.version, requirements);
+
+            return ({ current, latest, satisfied });
+        });
+};
+
+function withCompatibilityCheck(fn) {
+    return (...args) => {
+        const options = last(args) || {};
+        const { profile: profileName } = options;
+        const profile = loadProfile(profileName);
+
+        return getCompatibility(profile)
+            .then(({ current, latest, satisfied }) => {
+                if (!satisfied) {
+                    upgradeRequired({ current, latest });
+                }
+                else if (semver.gt(latest, current)) {
+                    upgradeAvailable({ current, latest });
+                }
+            })
+            .then(() => fn(...args))
+            .catch((error) => {
+                printError(error);
+            });
+    };
+};
+
+module.exports = {
+    getCompatibility,
+    withCompatibilityCheck
+}

--- a/src/config.js
+++ b/src/config.js
@@ -101,15 +101,15 @@ class Config {
     getProfile(name) {
         const profile = this.profiles[name];
         if (!profile) {
-            return null;
+            return undefined;
         }
 
         return new Profile(name, profile).validate();
     }
 
     setProfile(name, {url, account, tenantId, username, token}) {
-         const profile = new Profile(name, {url, username, account, tenantId, token});
-         profile.validate(); // do not set/save invalid profiles ..
+        const profile = new Profile(name, {url, username, account, tenantId, token});
+        profile.validate(); // do not set/save invalid profiles ..
         this.profiles[name] = profile
     }
 

--- a/test/compatibility.js
+++ b/test/compatibility.js
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2018 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+const findPackageJson = require('find-package-json');
+const rewire = require('rewire');
+const semver = require('semver');
+const superagent = require('superagent');
+const superagentMock = require('superagent-mocker');
+
+const compatibilityModule = rewire('../src/compatibility');
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+const pkg = findPackageJson(__dirname).next().value;
+
+describe('compatibility checks', function () {
+    const profile = {
+        url: 'http://example.com',
+        account: 'testAccount',
+        tenantId: 'testTenant',
+        username: 'testUser',
+        token: 'testToken'
+    };
+
+    describe('with a compatible application version', function () {
+        let requestMock;
+        let revertCompatibilityModule;
+
+        before(function () {
+            requestMock = superagentMock(superagent);
+            requestMock.get(
+                `${profile.url}/v3/catalog/compatibility/applications/cortex-cli`,
+                () => ({ ok: true, body: { semver: pkg.version } })
+            );
+            revertCompatibilityModule = compatibilityModule.__set__({
+                npmFetch: {
+                    json: () => Promise.resolve({ versions: { [pkg.version]: {} } })
+                },
+            });
+        });
+
+        after(function () {
+            revertCompatibilityModule();
+            requestMock.unmock(superagent);
+        });
+
+        it('should resolve as satisfied', function () {
+            const expected = { current: pkg.version, latest: pkg.version, satisfied: true };
+            return expect(compatibilityModule.getCompatibility(profile)).to.become(expected);
+        });
+    });
+
+    describe('with an incompatible application version', () => {
+        const nextMajorVersion = semver.inc(pkg.version, 'major');
+        let requestMock;
+        let revertCompatibilityModule;
+
+        before(() => {
+            requestMock = superagentMock(superagent);
+            requestMock.get(
+                `${profile.url}/v3/catalog/compatibility/applications/cortex-cli`,
+                () => ({ ok: true, body: { semver: nextMajorVersion } })
+            );
+            revertCompatibilityModule = compatibilityModule.__set__({
+                npmFetch: {
+                    json: () => Promise.resolve({
+                        versions: {
+                            [pkg.version]: {},
+                            [nextMajorVersion]: {}
+                        }
+                    })
+                },
+            });
+        });
+
+        after(() => {
+            revertCompatibilityModule();
+            requestMock.unmock(superagent);
+        });
+
+        it('should resolve as unsatisfied', () => {
+            const expected = { current: pkg.version, latest: nextMajorVersion, satisfied: false };
+            return expect(compatibilityModule.getCompatibility(profile)).to.become(expected);
+        });
+    });
+
+    describe('when the NPM registry cannot be reached', () => {
+        let requestMock;
+        let revertCompatibilityModule;
+
+        before(() => {
+            requestMock = superagentMock(superagent);
+            requestMock.get(
+                `${profile.url}/v3/catalog/compatibility/applications/cortex-cli`,
+                () => { throw new Error('BOOM!'); }
+            );
+            revertCompatibilityModule = compatibilityModule.__set__({
+                npmFetch: {
+                    json: () => Promise.resolve({ versions: { [pkg.version]: {} } })
+                },
+            });
+        });
+
+        after(() => {
+            revertCompatibilityModule();
+            requestMock.unmock(superagent);
+        });
+
+        it('should reject', () => {
+            return expect(compatibilityModule.getCompatibility(profile)).to.be.rejected;
+        });
+    });
+
+    describe('when the compatibility API cannot be reached', () => {
+        let requestMock;
+        let revertCompatibilityModule;
+
+        before(() => {
+            requestMock = superagentMock(superagent);
+            requestMock.get(
+                `${profile.url}/v3/catalog/compatibility/applications/cortex-cli`,
+                () => ({ ok: true, body: { semver: pkg.version } })
+            );
+            revertCompatibilityModule = compatibilityModule.__set__({
+                npmFetch: {
+                    json: () => Promise.reject(new Error('BOOM!'))
+                },
+            });
+        });
+
+        after(() => {
+            revertCompatibilityModule();
+            requestMock.unmock(superagent);
+        });
+
+        it('should reject', () => {
+            return expect(compatibilityModule.getCompatibility(profile)).to.be.rejected;
+        });
+    });
+});


### PR DESCRIPTION
Read it and weep :-(

`commander.js` usage of `process.spawn` for executing sub-commands makes it impossible for me to fetch the specified profile and run a compatibility check globally.  Rather than modifying every command's `execute()` method, I've kept the `/src/...` tree unaware of the checks, and instead created a Command.Action wrapper and is called by the cortex-* implementations in `/bin`.

I also made a few other cleanup changes (e.g. most of the generate commands didn't actually need a --profile options, etc.)