### PR TITLE
[CCF-6706] Add missing `--json` option to `variables` commands

### DIFF
--- a/bin/cortex-variables.js
+++ b/bin/cortex-variables.js
@@ -36,6 +36,7 @@ program
     .command('list')
     .description('List secure variable keys')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--json', 'Output results using JSON')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((options) => {
         try {
@@ -52,6 +53,7 @@ program
     .command('describe <keyName>')
     .description('Retrieve the value stored for the given variable key.')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--json', 'Output results using JSON')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((keyName, options) => {
         try {


### PR DESCRIPTION
Add missing `--json` option to `variables list` and `variables describe` commands.

NOTE: I'll `npm version patch && git push --tags && git push` in the develop branch after this is merged.