### PR TITLE
Add `--no-compat` option to bypass API compatibility checks

### DIFF
--- a/bin/cortex-accounts.js
+++ b/bin/cortex-accounts.js
@@ -40,6 +40,7 @@ program.description('Work with Cortex Accounts');
 program
     .command('create-groups <groupName>')
     .description('Create a group')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--description [description]', 'Group description')
@@ -57,6 +58,7 @@ program
 program
     .command('add-members-groups <groupName> [members...]')
     .description('Add members to group')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((groupName, members, options) => {
@@ -73,6 +75,7 @@ program
 program
     .command('list-groups')
     .description('List groups')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((options) => {
@@ -89,6 +92,7 @@ program
 program
     .command('describe-groups <groupName>')
     .description('Describe a group')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((groupName, options) => {
@@ -105,6 +109,7 @@ program
 program
     .command('delete-groups <groupName>')
     .description('Delete a group')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((groupName, options) => {
@@ -121,6 +126,7 @@ program
 program
     .command('remove-members-groups <groupName> [members...]')
     .description('Remove members from a group')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((groupName, members, options) => {
@@ -137,6 +143,7 @@ program
 program
     .command('register-resources <resourceName>')
     .description('Register a resource')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--description [description]', 'Resource description')
@@ -155,6 +162,7 @@ program
 program
     .command('grant-group-access-resources <resourceId> <groupName>')
     .description('Grant group access to a resource')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((resourceId, groupName, options) => {

--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -37,6 +37,7 @@ program.description('Work with Cortex Actions');
 program
     .command('list')
     .description('List the deployed actions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -55,6 +56,7 @@ program
 program
     .command('describe <actionName>')
     .description('Describe an action')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -73,6 +75,7 @@ program
 program
     .command('delete <actionName>')
     .description('Delete an action')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -91,6 +94,7 @@ program
 program
     .command('invoke <actionName>')
     .description('Invoke an action')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--params [params]', 'JSON params to send to the action')
     .option('--params-file [paramsFile]', 'A file containing either JSON or YAML formatted params')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
@@ -113,6 +117,7 @@ program
 program
     .command('deploy <actionName>')
     .description('Deploy an action')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--kind [kind]', 'Action runtime kind') // python:3, python:2, nodejs:default
     .option('--code [code]', 'The code file or code archive to deploy')
     .option('--docker [image]', 'Docker image to use as the runner')

--- a/bin/cortex-agents.js
+++ b/bin/cortex-agents.js
@@ -46,6 +46,7 @@ program.description('Work with Cortex Agents');
 program
     .command('save <agentDefinition>')
     .description('Save an agent definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
@@ -63,6 +64,7 @@ program
 program
     .command('list')
     .description('List agent definitions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -81,6 +83,7 @@ program
 program
     .command('describe <agentName>')
     .description('Describe agent')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -99,6 +102,7 @@ program
 program
     .command('invoke <agentName> <serviceName>')
     .description('Invoke an agent service')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--params [params]', 'JSON params to send to the action')
@@ -117,10 +121,11 @@ program
 program
     .command('get-service-activation <activationId>')
     .description('Get service activation')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
-    .action((activationId, options) => {
+    .action(withCompatibilityCheck((activationId, options) => {
         try {
             new GetServiceActivationCommand(program).execute(activationId, options);
             processed = true;
@@ -128,12 +133,13 @@ program
         catch (err) {
             console.error(chalk.red(err.message));
         }
-    });
+    }));
 
 
 program
     .command('list-snapshots <agentName>')
     .description('List agent snapshots')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
@@ -152,6 +158,7 @@ program
 program
     .command('describe-snapshot <snapshotId>')
     .description('Describe agent snapshot')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
@@ -169,11 +176,11 @@ program
 program
     .command('create-snapshot [snapshotDefinition]')
     .description('Create an agent snapshot')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--agentName [name[:version]]', 'The name of the agent to snapshot')
     .option('--title [title]', 'A descriptive title for the snapshot')
-
     .action(withCompatibilityCheck((snapshotDefinition, options) => {
         try {
             new CreateAgentSnapshotCommand(program).execute(snapshotDefinition, options);
@@ -189,6 +196,7 @@ program
 program
     .command('list-instances <agentName>')
     .description('List agent instances  ')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
@@ -208,11 +216,11 @@ program
 program
     .command('create-instance [instanceDefinition]')
     .description('Create agent instance')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--environmentName [environmentName]', 'The environment to use')
     .option('--profile [profile]', 'The profile to use')
     .option('--snapshotId [snapshotId]', 'The name of the agent to snapshot')
-
     .action(withCompatibilityCheck((instanceDefinition, options) => {
         try {
             new CreateAgentInstanceCommand(program).execute(instanceDefinition, options);
@@ -227,6 +235,7 @@ program
 program
     .command('get-instance <instanceId>')
     .description('Get agent instance')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -244,6 +253,7 @@ program
 program
     .command('delete-instance <instanceId>')
     .description('Delete agent instance')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((instanceId, options) => {
@@ -260,6 +270,7 @@ program
 program
     .command('stop-instance <instanceId>')
     .description('Stop agent instance')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((instanceId, options) => {
@@ -276,6 +287,7 @@ program
 program
     .command('list-triggers')
     .description('List of triggers for the current tenant')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((options) => {

--- a/bin/cortex-connections.js
+++ b/bin/cortex-connections.js
@@ -39,6 +39,7 @@ program.description('Work with Cortex Connections');
 program
     .command('list')
     .description('List connections definitions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -57,6 +58,7 @@ program
 program
     .command('save <connectionDefinition>')
     .description('Save a connections definition. Takes JSON file by default.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
@@ -74,6 +76,7 @@ program
 program
     .command('describe <connectionName>')
     .description('Describe connection')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -91,6 +94,7 @@ program
 program
     .command('test <connectionDefinition>')
     .description('Test a connections definition before saving. Takes JSON file by default.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for agent definition format')
@@ -108,6 +112,7 @@ program
 program
     .command('list-types')
     .description('List connections types')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')

--- a/bin/cortex-content.js
+++ b/bin/cortex-content.js
@@ -37,6 +37,7 @@ program.description('Work with Cortex Contents');
 program
     .command('list')
     .description('List content')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -55,6 +56,7 @@ program
 program
     .command('upload <contentKey> <filePath>')
     .description('Upload content')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--secure', 'Uploads the content securely to the Cortex Vault. Use this option for keytab files or content that contains sensitive information that is required during Runtime. Take note of the contentKey you give to this content for future reference.')
@@ -72,6 +74,7 @@ program
 program
     .command('delete <contentKey>')
     .description('Delete content')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((contentKey, options) => {
@@ -88,6 +91,7 @@ program
 program
     .command('download <contentKey>')
     .description('Download content')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--secure', 'Downloads the content securely from the Cortex Vault.')

--- a/bin/cortex-datasets.js
+++ b/bin/cortex-datasets.js
@@ -39,6 +39,7 @@ program.description('Work with Cortex Connections');
 program
     .command('list')
     .description('List Datasets')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using detailed JSON')
@@ -57,6 +58,7 @@ program
 program
     .command('save <datasetDefinition>')
     .description('Save a dataset definition. Takes JSON file by default.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for dataset file definition format')
@@ -74,6 +76,7 @@ program
 program
     .command('describe <datasetName>')
     .description('Describe dataset')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -91,6 +94,7 @@ program
 program
     .command('get-dataframe <datasetName>')
     .description('Get dataset in dataframe format')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((datasetName, options) => {
@@ -107,6 +111,7 @@ program
 program
     .command('get-stream <datasetName>')
     .description('Stream dataset content')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((datasetName, options) => {

--- a/bin/cortex-environments.js
+++ b/bin/cortex-environments.js
@@ -38,6 +38,7 @@ program.description('Work with Cortex Environments');
 program
     .command('list')
     .description('List environments')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -56,6 +57,7 @@ program
 program
     .command('save <environmentDefinition>')
     .description('Create an environment. Takes JSON file by default.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for environment definition format')
@@ -73,6 +75,7 @@ program
 program
     .command('promote [promotionDefinition]')
     .description('Promote a snapshot to an environment. Takes JSON file by default.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for environment definition format')
@@ -92,6 +95,7 @@ program
 program
     .command('describe <environmentName>')
     .description('Describe environment')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -111,6 +115,7 @@ program
 program
     .command('list-instances [environmentName]')
     .description('List instances in environment')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')

--- a/bin/cortex-jobs.js
+++ b/bin/cortex-jobs.js
@@ -37,6 +37,7 @@ program.description('Work with Cortex Jobs');
 program
     .command('list')
     .description('List job definitions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -55,6 +56,7 @@ program
 program
     .command('describe <jobDefinition>')
     .description('Describe job definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -72,6 +74,7 @@ program
 program
     .command('status <jobDefinition>')
     .description('Get job status')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -90,6 +93,7 @@ program
 program
     .command('save <jobDefinition>')
     .description('Save a job definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for job definition format')

--- a/bin/cortex-processors.js
+++ b/bin/cortex-processors.js
@@ -38,6 +38,7 @@ program.description('Work with the Cortex Processor Runtime');
 program
     .command('list-runtime-types')
     .description('List available processor runtime types')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -56,6 +57,7 @@ program
 program
     .command('list-runtimes')
     .description('List configured processor runtimes')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -74,6 +76,7 @@ program
 program
     .command('describe <runtimeName>')
     .description('Describe a processor runtime')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')
@@ -91,6 +94,7 @@ program
 program
     .command('delete <runtimeName>')
     .description('Delete a processor runtime')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .action(withCompatibilityCheck((runtimeName, options) => {
@@ -107,6 +111,7 @@ program
 program
     .command('list-actions <runtimeName>')
     .description('List the available processor runtime actions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -125,6 +130,7 @@ program
 program
     .command('invoke <runtimeName> <actionId>')
     .description('Invoke a processor action')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')

--- a/bin/cortex-skills.js
+++ b/bin/cortex-skills.js
@@ -36,6 +36,7 @@ program.description('Work with Cortex Skills');
 program
     .command('save <skillDefinition>')
     .description('Save a skill definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for skill definition format')
@@ -53,6 +54,7 @@ program
 program
     .command('list')
     .description('List skill definitions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -71,6 +73,7 @@ program
 program
     .command('describe <skillName>')
     .description('Describe skill')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')

--- a/bin/cortex-tasks.js
+++ b/bin/cortex-tasks.js
@@ -37,6 +37,7 @@ program.description('Work with Cortex Jobs');
 program
     .command('list <jobId>')
     .description('List task definitions within a job definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -55,6 +56,7 @@ program
 program
     .command('logs <jobId> <taskId>')
     .description('Get Tasks logs')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -73,6 +75,7 @@ program
 program
     .command('cancel <jobId> <taskId>')
     .description('Cancel a task')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -91,6 +94,7 @@ program
 program
     .command('describe <jobId> <taskId>')
     .description('Describe a task definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')

--- a/bin/cortex-types.js
+++ b/bin/cortex-types.js
@@ -35,6 +35,7 @@ program.description('Work with Cortex Types');
 program
     .command('save <typeDefinition>')
     .description('Save a type definition')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('-y, --yaml', 'Use YAML for type definition format')
@@ -52,6 +53,7 @@ program
 program
     .command('list')
     .description('List type definitions')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--json', 'Output results using JSON')
@@ -70,6 +72,7 @@ program
 program
     .command('describe <typeName>')
     .description('Describe type')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'A JMESPath query to use in filtering the response data.')

--- a/bin/cortex-variables.js
+++ b/bin/cortex-variables.js
@@ -35,6 +35,7 @@ program.description('Work with Cortex Secure Variables');
 program
     .command('list')
     .description('List secure variable keys')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--json', 'Output results using JSON')
     .option('--profile [profile]', 'The profile to use')
@@ -52,6 +53,7 @@ program
 program
     .command('describe <keyName>')
     .description('Retrieve the value stored for the given variable key.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--json', 'Output results using JSON')
     .option('--profile [profile]', 'The profile to use')
@@ -69,6 +71,7 @@ program
 program
     .command('save <keyName> [value]')
     .description('Save or overwrite a secure variable value. By default, values are stored as strings but can also be saved as JSON or YAML values.')
+    .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--data [data]', 'JSON value to save')
     .option('--data-file [dataFile]', 'A file containing either JSON or YAML formatted value to save')

--- a/src/compatibility.js
+++ b/src/compatibility.js
@@ -113,22 +113,27 @@ function getCompatibility(profile) {
 function withCompatibilityCheck(fn) {
     return (...args) => {
         const options = last(args) || {};
-        const { profile: profileName } = options;
-        const profile = loadProfile(profileName);
 
-        return getCompatibility(profile)
-            .then(({ current, latest, satisfied }) => {
-                if (!satisfied) {
-                    upgradeRequired({ current, latest });
-                }
-                else if (semver.gt(latest, current)) {
-                    upgradeAvailable({ current, latest });
-                }
-            })
-            .then(() => fn(...args))
-            .catch((error) => {
-                printError(error);
-            });
+        if (options.compat) {
+            const { profile: profileName } = options;
+            const profile = loadProfile(profileName);
+
+            return getCompatibility(profile)
+                .then(({ current, latest, satisfied }) => {
+                    if (!satisfied) {
+                        upgradeRequired({ current, latest });
+                    }
+                    else if (semver.gt(latest, current)) {
+                        upgradeAvailable({ current, latest });
+                    }
+                })
+                .then(() => fn(...args))
+                .catch((error) => {
+                    printError(error);
+                });
+        }
+
+        return Promise.resolve().then(() => fn(...args));
     };
 };
 


### PR DESCRIPTION
I'll bump to 0.9.0 after merged. Yes, I'm sad about how I had to implement this.