### PR TITLE
Support streaming and non-text download of managed content

### DIFF
--- a/src/commands/content.js
+++ b/src/commands/content.js
@@ -160,16 +160,16 @@ module.exports.DownloadContent = class DownloadContent {
         else {
             content.downloadContent(profile.token, contentKey).then((response) => {
                 if (response.success) {
-                    printSuccess(response.message, options);
+                    // messages need to be on stderr as content is streamed to stdout
+                    console.error(response.message);
                 }
                 else {
                     printError(`Failed to download content: ${response.status} ${response.message}`, options);
                 }
-            })
-                .catch((err) => {
+            }).catch((err) => {
                     debug(err);
                     printError(`Failed to download content: ${err.status} ${err.message}`, options);
-                });
+            });
         }
 
     }


### PR DESCRIPTION
Lets you download non-text content such as a zip, to stdout (which can be redirected to a file), using streaming. Will detect an error rather than treating the json returned by content API as if it was the downloaded content. Outputs errors and success message to stderr, so it doesnt interfere with redirecting content to a file.
