### PR TITLE
CCF-7909-cli-docker-login

### DIFF
--- a/bin/cortex-docker.js
+++ b/bin/cortex-docker.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2018 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const chalk = require('chalk');
+const program = require('../src/commander');
+
+const { withCompatibilityCheck } = require('../src/compatibility');
+
+const {
+    DockerLoginCommand,
+} = require('../src/commands/docker');
+
+program.description('Work with Docker');
+
+// Login
+program
+    .command('login')
+    .description('Docker login to the Cortex registry with your jwt token')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .action(withCompatibilityCheck((options) => {
+        try {
+            new DockerLoginCommand(program).execute(options);
+        }
+        catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+program.parse(process.argv);

--- a/bin/cortex.js
+++ b/bin/cortex.js
@@ -34,6 +34,7 @@ program
     .command('content [cmd]', 'Work with Cortex Managed Content')
     .command('environments [cmd]', 'Work with Cortex Environments')
     .command('datasets [cmd]', 'Work with Cortex Datasets')
+    .command('docker [cmd]', 'Work with Docker')
     .command('jobs [cmd]', 'Work with Cortex Jobs')
     .command('processors [cmd]', 'Work with the Cortex Processor Runtime')
     .command('project [cmd]', 'Work with a related collection of Cortex contributions')
@@ -49,4 +50,3 @@ if (!program.commands.map(cmd => cmd._name).includes(program.args[0])) {
     program.outputHelp(identity);
     process.exit(1);
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/src/commands/docker.js
+++ b/src/commands/docker.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('cortex:cli');
+const {loadProfile} = require('../config');
+const {printSuccess, printError} = require('./utils');
+const Actions = require('../client/actions');
+const { callMe } = require('../commands/utils');
+
+module.exports.DockerLoginCommand = class {
+
+    constructor(program) {
+        this.program = program;
+    }
+
+    async execute(options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.executeDockerLogin()', profile.name);
+
+        const action = new Actions(profile.url);
+        const registryUrl = await action._cortexRegistryUrl(profile.token);
+        try {
+            await callMe(`docker login -u cli --password ${profile.token} ${registryUrl}`);
+            printSuccess(JSON.stringify('Login Succeeded', null, 2), options);
+        } catch (err) {
+            printError(`Failed to docker login: ${err.message || err}`, options);
+        }
+    }
+};


### PR DESCRIPTION
Added `cortex docker login` command.
It performs a `docker login` against the Cortex registry using the
profile's JWT.