### PR TITLE
CCF-8404 support environment variables for actions deploy

### DIFF
--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -128,6 +128,7 @@ program
     .option('--port [port]', 'Docker port')                  //'9091'
     .option('--environment [environment]', 'Environment')
     .option('--cmd [cmd]', 'Command to be executed')    //'["--daemon"]'
+    .option('--environmentVariables [environmentVariables]', 'Docker container environment variables, only used for daemon action types')
     .option('--push-docker', 'Push Docker image to the Cortex registry.')    
     .action(withCompatibilityCheck((actionName, options) => {
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -54,7 +54,7 @@ module.exports = class Actions {
         });
     }
 
-    async deployAction(token, actionName, docker, kind, code, memory, timeout, actionType, command, port, environment, pushDocker) {
+    async deployAction(token, actionName, docker, kind, code, memory, timeout, actionType, command, port, environment, environmentVariables, pushDocker) {
         let endpoint = `${this.endpointV3}`;
         if (actionType) {
             endpoint = `${endpoint}?actionType=${actionType}`;
@@ -81,6 +81,7 @@ module.exports = class Actions {
         if (command) req.field('command', command);
         if (port) req.field('port', port);
         if (environment) req.field('environment', environment);
+        if (environmentVariables) req.field('environmentVariables', environmentVariables);
 
         return req.then((res) => {
             if (res.ok) {

--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -108,10 +108,11 @@ module.exports.DeployActionCommand = class {
         const cmd = options.cmd;
         const port = options.port;
         const environment = options.environment;
+        const environmentVariables = options.environmentVariables;
         const pushDocker = options.pushDocker;
 
         const actions = new Actions(profile.url);
-        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, timeout, actionType, cmd, port, environment, pushDocker)
+        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, timeout, actionType, cmd, port, environment, environmentVariables, pushDocker)
             .then((response) => {
                 if (response.success) {
                     printSuccess(JSON.stringify(response.message, null, 2), options);


### PR DESCRIPTION
Added support for an actions deploy option in the following formats:
* --environmentVariables '"env.var"="Environment Variable", "my.env.var"="Hello World!"'
* --environmentVariables '"env.var":"Environment Variable", "my.env.var":"Hello World!"'

Actions describe returns the environment variables for the action if they exist.
Currently, environment variables is only supported for daemons.