### PR TITLE
fixing undefined error when promoting a snapshot to an environment, i…

### DIFF
--- a/src/commands/environments.js
+++ b/src/commands/environments.js
@@ -185,7 +185,7 @@ module.exports.PromoteEnvironmentCommand = class PromoteEnvironmentCommand {
         environment.promoteEnvironment(profile.token, promObj)
             .then((response) => {
                 if (response.success) {
-                    printSuccess(`Snapshot \'${promObj.snapshotId}\' successfully promoted to \'${promObj.environmentName}\' environment. Instance \'${response.instanceId}\' created.`, options);
+                    printSuccess(`Snapshot \'${promObj.snapshotId}\' successfully promoted to \'${promObj.environmentName}\' environment. Instance \'${response.message.instanceId}\' created.`, options);
                 } else {
                     let errMsg = `Failed to promote to environment: ${response.status} ${response.message}\n`;
                     if (response.details) {


### PR DESCRIPTION
…nstanceId is under `response.message.instanceId`