### PR TITLE
working recursive upload of directory

### DIFF
--- a/bin/cortex-content.js
+++ b/bin/cortex-content.js
@@ -54,6 +54,8 @@ program
     .command('upload <contentKey> <filePath>')
     .description('Upload content')
     .option('--progress', 'Show upload progress')
+    .option('--test', 'Show what would be uploaded along with file size')
+    .option('--recursive', 'Recursively walk <filePath> and prefix each path stored with <contentKey>')
     .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "debug": "3.1.0",
     "event-stream": "3.3.4",
     "find-package-json": "1.1.0",
+    "glob": "^7.1.3",
     "is-installed-globally": "0.1.0",
     "jmespath": "0.15.0",
     "joi": "13.1.0",

--- a/test/cortex/sample/upload/config
+++ b/test/cortex/sample/upload/config
@@ -1,0 +1,12 @@
+{
+    "version": "2",
+    "profiles": {
+        "test": {
+            "url": "http://localhost:8000",
+            "username": "test_user",
+            "account": "test_account",
+            "token": "DUMMY_TOKEN"
+        }
+    },
+    "currentProfile": "test"
+}

--- a/test/uploadDirectory.js
+++ b/test/uploadDirectory.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const commander = require('commander');
+const { UploadContent } = require('../src/commands/content');
+const { humanReadableFileSize } = require('../src/commands/utils');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Upload Directory', function () {
+    it('test upload', (done) =>  {
+        const program = new commander.Command();
+        const command = new UploadContent(program);
+        const contentKey = '.shared';
+
+        const filePath = `${__dirname}/cortex`;
+        const options = {
+            'recursive': true,
+            'test': true
+        };
+
+        const expectedFileDicts = [
+            { canonical: `${__dirname}/cortex/config`,
+              relative: 'config',
+              size: 260
+            },
+            { canonical: `${__dirname}/cortex/sample/upload/config`,
+              relative: 'sample/upload/config',
+              size: 260
+            }
+        ];
+
+        command.execute(contentKey, filePath, options, (fileDicts) => {
+            expect(fileDicts).to.deep.equal(expectedFileDicts);
+            done();
+        });
+    });
+});
+
+describe('Human Readable File Size', function () {
+    it('bytes', (done) =>  {
+        const sizeInBytes = 260;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('260B');
+        done();
+    });
+    it('KB', (done) =>  {
+        const sizeInBytes = 1200;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('1.2K');
+        done();
+    });
+
+    it('MB', (done) =>  {
+        const sizeInBytes = 1000000;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('1M');
+        done();
+    });
+
+    it('1MB less some', (done) =>  {
+        const sizeInBytes = Math.pow(10, 3) - 1;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('999B');
+        done();
+    });
+
+    it('1k 200 bytes less', (done) =>  {
+        const sizeInBytes = 1000000 - 200;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('999.8K');
+        done();
+    });
+
+    it('1k less', (done) =>  {
+        const sizeInBytes = Math.pow(10, 6) - 1;
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('999.9K');
+        done();
+    });
+
+    it('several GB', (done) =>  {
+        const sizeInBytes = 32 * Math.pow(10, 9) + 345 * Math.pow(10, 6);
+        const formattedFileSize = humanReadableFileSize(sizeInBytes);
+        expect(formattedFileSize).to.have.string('32.3G');
+        done();
+    });
+});


### PR DESCRIPTION
Now able to upload entire directory to our managed content:
Here is a shared example:

`cortex content upload .shared /Users/dwisecup/code/c5/ccf-9417/upload --recursive`
`
18.7K	conn_types/cdata_conn_types.json -> .shared/conn_types/cdata_conn_types.json
18.7K	conn_types/cdata_conn_types2.json -> .shared/conn_types/cdata_conn_types2.json
7.4M	drivers/cdata.jdbc.actcrm_18.0.6886.0.jar -> .shared/drivers/cdata.jdbc.actcrm_18.0.6886.0.jar
7.4M	drivers/cdata.jdbc.test_18.0.6886.0.jar -> .shared/drivers/cdata.jdbc.test_18.0.6886.0.jar
174B	keys/cdata_rtk.json -> .shared/keys/cdata_rtk.json
174B	keys/cdata_rtk2.json -> .shared/keys/cdata_rtk2.json
174B	keys/more_keys/cdata_rtk.json -> .shared/keys/more_keys/cdata_rtk.json
174B	keys/more_keys/even_more/keys/cdata_rtk.json -> .shared/keys/more_keys/even_more/keys/cdata_rtk.json

Total:
14.8M	/Users/dwisecup/code/c5/ccf-9417/upload
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
Content successfully uploaded.
`