### PR TITLE
Add `cortex agents list-snapshot-instances`

### DIFF
--- a/bin/cortex-agents.js
+++ b/bin/cortex-agents.js
@@ -29,6 +29,7 @@ const {
     GetActivationCommand,
     ListActivationsCommand,
     ListAgentInstancesCommand,
+    ListSnapshotInstancesCommand,
     CreateAgentInstanceCommand,
     GetAgentInstanceCommand,
     DeleteAgentInstanceCommand,
@@ -202,6 +203,25 @@ program
     .action(withCompatibilityCheck((agentName, options) => {
         try {
             new ListAgentSnapshotsCommand(program).execute(agentName, options);
+        }
+        catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+//List snapshot instances
+program
+    .command('list-snapshot-instances <snapshotId>')
+    .description('List snapshot instances  ')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .option('--environmentName [environmentName]', 'The environment to list or \'all\'')
+    .option('--json', 'Output results using JSON')
+    .option('--query [query]', 'A JMESPath query to use in filtering the response data. Ignored if output format is not JSON.')
+    .action(withCompatibilityCheck((snapshotId, options) => {
+        try {
+            new ListSnapshotInstancesCommand(program).execute(snapshotId, options);
         }
         catch (err) {
             console.error(chalk.red(err.message));

--- a/src/client/agents.js
+++ b/src/client/agents.js
@@ -111,6 +111,29 @@ module.exports = class Agents {
             });
     }
 
+
+    listSnapshotInstances(token, snapshotId, environmentName) {
+        let endpoint = `${this.endpoint}/instances?snapshot=${snapshotId}`;
+        debug('listSnapshotInstances(%s, %s) => (%s)', snapshotId, environmentName, endpoint);
+        if (environmentName) endpoint = `${endpoint}&environmentName=${environmentName}`;
+
+        return request
+            .get(endpoint)
+            .set('Authorization', `Bearer ${token}`)
+            .set('x-cortex-proxy-notify', true)
+            .then((res) => {
+                if (Boolean(_.get(res, 'headers.x-cortex-proxied', false)))
+                    console.error(chalk.blue('Request proxied to cloud.'));
+                if (res.ok) {
+                    return {success: true, instances: res.body.instances};
+                }
+                return {success: false, status: res.status, message: res.body};
+            })
+            .catch((err) => {
+                return constructError(err);
+            });
+    }
+
     describeAgentSnapshot(token, snapshotId, environmentName) {
         let endpoint = `${this.endpoint}/snapshots/${snapshotId}?deps=true`;
         debug('describeAgentSnapshot(%s, %s) => %s', snapshotId, environmentName, endpoint);

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -364,6 +364,45 @@ module.exports.ListAgentSnapshotsCommand = class {
     }
 };
 
+module.exports.ListSnapshotInstancesCommand = class {
+
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(snapshotId, options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.listSnapshotInstances(%s)', profile.name, snapshotId);
+
+        const agents = new Agents(profile.url);
+        const envName = options.environmentName;
+        agents.listSnapshotInstances(profile.token, snapshotId, envName).then((response) => {
+            if (response.success) {
+                let result = filterObject(response.instances, options);
+                if (options.json) {
+                    printSuccess(JSON.stringify(result, null, 2), options);
+                }
+                else {
+                    const tableSpec = [
+                        { column: 'Instance Id', field: 'instanceId', width: 26 },
+                        { column: 'Status', field: 'status', width: 15 },
+                        { column: 'Environment Id', field: 'environmentName', width: 26 },
+                        { column: 'Created At', field: 'createdAt', width: 26 },
+                    ];
+                    printTable(tableSpec, result);
+                }
+
+            }
+            else {
+                printError(`Failed to list instances for snapshot ${snapshotId}: ${response.message}`, options);
+            }
+        })
+            .catch((err) => {
+                printError(`Failed to list instances for snapshot ${snapshotId}: ${err.status} ${err.message}`, options);
+            });
+    }
+};
+
 
 module.exports.DescribeAgentSnapshotCommand = class {
     constructor(program) {


### PR DESCRIPTION
Allow user to query the list of instances for a snapshot. Optionally specify environmentName.

JSON-formatted response is similar to:
```
[
  {
    "instanceId": "5c7463e2d1ae6327d757c755",
    "status": "started",
    "snapshotId": "5335fda4-225d-434c-9e73-547178fc93e3",
    "environmentName": "cortex/default",
    "createdAt": "2019-02-25T21:53:38.934Z"
  }
]
```
Table lists the above fields other than snapshotId.