### PR TITLE
Release 0.12.14 b

### DIFF
--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -124,7 +124,6 @@ program
     .option('--docker [image]', 'Docker image to use as the runner')
     .option('--memory [memory]', 'Action memory limit in megabytes')
     .option('--vcpus [vcpus]', 'Action vcpus limit in integer')
-    .option('--timeout [timeout]', 'Execution timeout in milliseconds', '60000')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--actionType [actionType]', 'Type of action')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/CognitiveScale/cortex-cli",
   "dependencies": {
-    "@c12e/generator-cortex": "0.3.18",
+    "@c12e/generator-cortex": "0.3.19",
     "boxen": "1.3.0",
     "chalk": "2.3.0",
     "cli-table": "0.3.1",

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+# Checklist:
+Please check you fulfill ALL of the relevant checkboxes
+- [ ] Notified docs of any potential USER-facing changes
+- [ ] Added short description of the change - with relevant motivation and context. 
+- [ ] Branch has the ticket number in its name (along with a ticket summary)
+- [ ] Commented the code, particularly in hard-to-understand areas
+- [ ] Added tests that prove my fix is effective or that my feature works
+- [ ] Ran `npm test` and it passes
+- [ ] Changes generate no new warnings

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -54,13 +54,13 @@ module.exports = class Actions {
         });
     }
 
-    async deployAction(token, actionName, docker, kind, code, memory, vcpus, timeout, actionType, command, port, environment, environmentVariables, pushDocker) {
+    async deployAction(token, actionName, docker, kind, code, memory, vcpus, actionType, command, port, environment, environmentVariables, pushDocker) {
         let endpoint = `${this.endpointV3}`;
         if (actionType) {
             endpoint = `${endpoint}?actionType=${actionType}`;
         }
-        debug('deployAction(%s, docker=%s, kind=%s, code=%s, memory=%s, vcpus=%s, timeout=%s) => %s',
-            actionName, docker, kind, code, memory, vcpus, timeout, endpoint);
+        debug('deployAction(%s, docker=%s, kind=%s, code=%s, memory=%s, vcpus=%s) => %s',
+            actionName, docker, kind, code, memory, vcpus, endpoint);
 
         try {
             docker = await this._maybePushDockerImage(docker, token, pushDocker);
@@ -77,7 +77,6 @@ module.exports = class Actions {
         if (kind) req.field('kind', kind);
         if (memory) req.field('memory', memory);
         if (vcpus) req.field('vcpus', vcpus);
-        if (timeout) req.field('timeout', timeout);
         if (code) req.attach('code', code);
         if (command) req.field('command', command);
         if (port) req.field('port', port);

--- a/src/client/catalog.js
+++ b/src/client/catalog.js
@@ -125,7 +125,7 @@ module.exports = class Catalog {
                 const urlBase = `${profile.url}/${AGENTS_API_VERSION}/agents/${agentName}/services`;
                 const servicesList = response.agent.inputs
                     .filter(i => i.signalType === 'Service')
-                    .map(i => ({ ...i, url: `${urlBase}/${i.name}` }));
+                    .map(i => ({ ...i, url: `${urlBase}/${i.name}` }))
                 return { success: true, services: servicesList };
             } else {
                 return response;

--- a/src/client/content.js
+++ b/src/client/content.js
@@ -95,7 +95,9 @@ module.exports = class Content {
         return new Promise((resolve) => {
             fs
                 .createReadStream(content)
-                .on('data', (chunk) => progressBar && progressBar.tick(chunk.length))
+                .on('data', (chunk) => {
+                    progressBar && progressBar.tick(chunk.length);
+                })
                 .pipe(request
                     .post({
                         uri: url,
@@ -104,14 +106,14 @@ module.exports = class Content {
                             'Authorization': `Bearer ${token}`,
                             'Content-Type': contentType,
                         }
-                    })
-                    .on('response', (res) => {
+                    }, function(err, res, body) {
                         if (res.statusCode === 200) {
-                            resolve({success: true, message: res.body});
+                            resolve({success: true, message: body});
+                            return;
                         }
-                        resolve({success: false, message: res.body, status: res.status});
+                        // NOTE this is using npm request NOT superagent - fields are different
+                        resolve({success: false, message: body, status: res.statusCode});
                     })
-                    .on('error', (err) => resolve(constructError(err)))
                 );
         });
     }

--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -105,7 +105,6 @@ module.exports.DeployActionCommand = class {
         const code = options.code;
         const memory = parseInt(options.memory);
         const vcpus = parseInt(options.vcpus);
-        const timeout = parseInt(options.timeout);
         const actionType = options.actionType;
         const cmd = options.cmd;
         const port = options.port;
@@ -114,7 +113,7 @@ module.exports.DeployActionCommand = class {
         const pushDocker = options.pushDocker;
 
         const actions = new Actions(profile.url);
-        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, vcpus, timeout, actionType, cmd, port, environment, environmentVariables, pushDocker)
+        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, vcpus, actionType, cmd, port, environment, environmentVariables, pushDocker)
             .then((response) => {
                 if (response.success) {
                     printSuccess(JSON.stringify(response.message, null, 2), options);

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -299,7 +299,7 @@ module.exports.ListServicesCommand = class ListServicesCommand{
 
     execute(agentName, options) {
         const profile = loadProfile(options.profile);
-        debug('%s.listServices(%s)', profile.name, agentName); 
+        debug('%s.listServices(%s)', profile.name, agentName);
         
         const catalog = new Catalog(profile.url);
         catalog.listServices(profile.token, agentName, profile).then((response) => {

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -64,6 +64,10 @@ module.exports.ConfigureCommand = class {
             debug('account: %s', account);
             debug('username: %s', username);
 
+            if (!cortexUrl.match(/^[a-zA-Z]+:\/\//)) {
+                cortexUrl = 'http://' + cortexUrl;
+            }
+
             if (!cortexUrl) {
                 console.error(chalk.red('Cortex URL must be provided'));
                 return;


### PR DESCRIPTION
From what I can see, `develop` and `master` diverged at commit `65b3919` made against master, not part of the `develop` branch. 
So all commits to develop since the commit previous to it (`897ca9f`) are divorced from the `master` branch.
In order to have the latest dev (this release) be mergeable to `master`, I did a squash of all the commits from `5c30f1f` (the point at which develop and master bifurcate) on *this* branch and rebased on `master`. So this PR merges fine. I verified that `git diff develop master` is the same as `git diff release0.12.14-b master`. 

This hack only allows us to merge the latest changes in develop to master for the release, but develop is still out of sync with master. We'll have to fix this for real. If you guys think this is too ugly and we need to fix it for realz before the release, give me ideas. Thanks!

## Changes

Ccf 9171 memory vcpu mismatch (#155)

* don't use default command line params for memory and vcpus

* 0.12.9

Bump lodash for vunerabilities
CCF-9252 update generator for linux

CCF-9376 update generator version to 0.3.18 (#163)

CCF-9286: return instanceId in the message when promoting a snapshot … (#162)

* CCF-9286: return instanceId in the message when promoting a snapshot to an environment that was being returned by the api response but not getting included in the cli response

* updated message with review comments

fixing undefined error when promoting a snapshot to an environment, instanceId is under `response.message.instanceId` (#164)

working recursive upload of directory (#165)

* working recursive upload of directory

* 0.12.12

Remove cortex-processors commands (#166)

Add agents list-snapshot-instances (#168)

Chunk directory upload (#169)

* use sequential chunks of files to upload

* 0.12.13

Fix invalid query param on list snap instances (#170)

Updated list-services command to display the parameter names/types as well (#171)

CCF-9783 reverting changes to agent and catalog (#173)

Remove --timeout option from actions deploy (#175)

Ccf 9955 configure url (#176)

* add protocol prefix if one is missing

* 0.12.14

Return error message from content upload properly

Bump generator-cortex to pick up with_type change

created template checklist as POC

updated pull_request_template

Update pull_request_template.md

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
