### PR TITLE
Tweaks to error handling

### DIFF
--- a/src/client/content.js
+++ b/src/client/content.js
@@ -107,6 +107,10 @@ module.exports = class Content {
                             'Content-Type': contentType,
                         }
                     }, function(err, res, body) {
+                        if (err) {
+                            resolve({success: false, message: err.message});
+                            return;
+                        }
                         if (res.statusCode === 200) {
                             resolve({success: true, message: body});
                             return;

--- a/src/commands/content.js
+++ b/src/commands/content.js
@@ -80,7 +80,7 @@ module.exports.UploadContent = class UploadContent {
         const upload = _.partial(UploadContent.upload, contentClient, profile, options);
 
         if (options.recursive) {
-            getSourceFiles(filePath, (filesDict, err) => {
+            getSourceFiles(filePath, (err, filesDict) => {
                 if (err) {
                     debug(err);
                     printError(`Failed to upload content: ${err.status} ${err.message}`, options);

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -152,7 +152,7 @@ module.exports.getSourceFiles = function(source, cb) {
     glob(normalizedPath, options, function (err, files) {
         // files is an array of filenames.
         if (err) {
-            cb(err);
+            cb(err, null);
         } else {
             const results = files.filter(path => fs.lstatSync(path).isFile()).map((path) => {
                 return {
@@ -161,7 +161,7 @@ module.exports.getSourceFiles = function(source, cb) {
                     size: fs.lstatSync(path).size,
                 };
             });
-            cb(results);
+            cb(null, results);
         }
     });
 };


### PR DESCRIPTION
Fix handling of non-http errors, like network or filesystem issues
Fix error propagation from getSourceFiles() in callbacks errors are typically first.