### PR TITLE
CCF-11612 add connection query command

### DIFF
--- a/bin/cortex-connections.js
+++ b/bin/cortex-connections.js
@@ -24,6 +24,7 @@ const { withCompatibilityCheck } = require('../src/compatibility');
 const {
     ListConnections,
     SaveConnectionCommand,
+    QueryConnectionCommand,
     DescribeConnectionCommand,
     TestConnectionCommand,
     ListConnectionsTypes,
@@ -62,6 +63,23 @@ program
     .action(withCompatibilityCheck((connDefinition, options) => {
         try {
             new SaveConnectionCommand(program).execute(connDefinition, options);
+        }
+        catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+// Query Connection
+program
+    .command('query <connectionName>')
+    .description('Query a connection.')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .option('--query [query]', 'The query to use, "select 1" is default')
+    .action(withCompatibilityCheck((connName, options) => {
+        try {
+            new QueryConnectionCommand(program).execute(connName, options);
         }
         catch (err) {
             console.error(chalk.red(err.message));

--- a/bin/cortex-connections.js
+++ b/bin/cortex-connections.js
@@ -77,6 +77,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--query [query]', 'The query to use, "select 1" is default')
+    .option('--file [file]', 'Location of file containing query string')
     .action(withCompatibilityCheck((connName, options) => {
         try {
             new QueryConnectionCommand(program).execute(connName, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.17",
+  "version": "0.12.18",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/src/client/connections.js
+++ b/src/client/connections.js
@@ -25,13 +25,13 @@ module.exports = class Connections {
         this.endpoint = `${cortexUrl}/v2/connections`;
     }
 
-    queryConnection(token, connectionName, query) {
+    queryConnection(token, connectionName, queryObject) {
         const queryEndpoint = `${this.endpoint}/${connectionName}/query`
         // console.log('queryConnection(%s) => %s', connectionName, queryEndpoint);
         return request
             .post(queryEndpoint)
             .set('Authorization', `Bearer ${token}`)
-            .send({ query })
+            .send(queryObject)
             .then((res) => {
                 if (res.ok) {
                     return {success: true, message: res.body};

--- a/src/client/connections.js
+++ b/src/client/connections.js
@@ -25,13 +25,13 @@ module.exports = class Connections {
         this.endpoint = `${cortexUrl}/v2/connections`;
     }
 
-    queryConnection(token, connectionName, connObj) {
+    queryConnection(token, connectionName, query) {
         const queryEndpoint = `${this.endpoint}/${connectionName}/query`
-        debug('queryConnection(%s) => %s', connectionName, queryEndpoint);
+        // console.log('queryConnection(%s) => %s', connectionName, queryEndpoint);
         return request
             .post(queryEndpoint)
             .set('Authorization', `Bearer ${token}`)
-            .send(connObj)
+            .send({ query })
             .then((res) => {
                 if (res.ok) {
                     return {success: true, message: res.body};

--- a/src/client/connections.js
+++ b/src/client/connections.js
@@ -25,6 +25,24 @@ module.exports = class Connections {
         this.endpoint = `${cortexUrl}/v2/connections`;
     }
 
+    queryConnection(token, connectionName, connObj) {
+        const queryEndpoint = `${this.endpoint}/${connectionName}/query`
+        debug('queryConnection(%s) => %s', connectionName, queryEndpoint);
+        return request
+            .post(queryEndpoint)
+            .set('Authorization', `Bearer ${token}`)
+            .send(connObj)
+            .then((res) => {
+                if (res.ok) {
+                    return {success: true, message: res.body};
+                }
+                return {success: false, message: res.body, status: res.status};
+            })
+            .catch((err) => {
+                return constructError(err);
+            });
+    }
+
     listConnections(token) {
         const endpoint = `${this.endpoint}`;
         return request

--- a/src/commands/connections.js
+++ b/src/commands/connections.js
@@ -294,15 +294,19 @@ module.exports.QueryConnectionCommand = class QueryConnectionCommand {
 
         debug('params: %o', options);
 
+        if(options.file) {
+            options.query = fs.readFileSync(options.file, 'UTF-8');
+        }
+
         if(!options.query) {
             options.query = 'select 1';
         }
 
         const connections = new Connections(profile.url);
-        connections.queryConnection(profile.token, connectionName, options)
+        connections.queryConnection(profile.token, connectionName, options.query)
             .then((response) => {
                 if (response.success) {
-                    printSuccess(JSON.stringify(response, null, 2), options);
+                    printSuccess(JSON.stringify(response.message, null, 2), options);
                 }
                 else {
                     printError(`Failed to query connection: ${response.status} ${response.message}`, options);

--- a/src/commands/connections.js
+++ b/src/commands/connections.js
@@ -282,6 +282,38 @@ module.exports.ListConnectionsTypes = class ListConnectionsTypes {
     }
 };
 
+module.exports.QueryConnectionCommand = class QueryConnectionCommand {
+
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(connectionName, options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.executeQueryConnection(%s)', profile.name, connectionName);
+
+        debug('params: %o', options);
+
+        if(!options.query) {
+            options.query = 'select 1';
+        }
+
+        const connections = new Connections(profile.url);
+        connections.queryConnection(profile.token, connectionName, options)
+            .then((response) => {
+                if (response.success) {
+                    printSuccess(JSON.stringify(response, null, 2), options);
+                }
+                else {
+                    printError(`Failed to query connection: ${response.status} ${response.message}`, options);
+                }
+            })
+            .catch((err) => {
+                printError(`Failed to query connection: ${err.status} ${err.message}`, options);
+            });
+    }
+};
+
 module.exports.GenerateConnectionCommand = class GenerateConnectionCommand {
 
     constructor(program) {

--- a/src/commands/connections.js
+++ b/src/commands/connections.js
@@ -294,6 +294,8 @@ module.exports.QueryConnectionCommand = class QueryConnectionCommand {
 
         debug('params: %o', options);
 
+        let queryObject = {};
+
         if(options.file) {
             options.query = fs.readFileSync(options.file, 'UTF-8');
         }
@@ -302,8 +304,23 @@ module.exports.QueryConnectionCommand = class QueryConnectionCommand {
             options.query = 'select 1';
         }
 
+        try {
+            queryObject = JSON.parse(options.query);
+
+            if(queryObject.filter) {
+                queryObject.filter = JSON.stringify(queryObject.filter);
+            }
+            if(queryObject.sort) {
+                queryObject.sort = JSON.stringify(queryObject.sort);
+            }
+        } catch (err) {
+            queryObject.query = options.query;
+        }
+
+        debug('queryParams: %o', queryObject);
+
         const connections = new Connections(profile.url);
-        connections.queryConnection(profile.token, connectionName, options.query)
+        connections.queryConnection(profile.token, connectionName, queryObject)
             .then((response) => {
                 if (response.success) {
                     printSuccess(JSON.stringify(response.message, null, 2), options);


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings

Added a new command to query a connection.  Defaults to use 'select 1' if no query option is selected.  Was helpful in some of my testing so figured it may be a good addition to the cortex-cli.  Will update the package.json in a later commit once this goes through some iterations
