### PR TITLE
Tolerate daemon logs as array or structured response

### DIFF
--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -137,7 +137,11 @@ module.exports = class Actions {
             .set('Authorization', `Bearer ${token}`)
             .then((res) => {
                 if (res.ok) {
-                    return {success: true, logs: res.body};
+                    if (_.isArray(res.body)) {
+                        // returns plain array for Rancher daemons
+                        return {success: true, logs: res.body};
+                    }
+                    return res.body;
                 }
                 return {success: false, status: res.status, message: res.body};
             })


### PR DESCRIPTION
Fix so it tolerates return of array of strings from API (for Rancher daemons) or the more standard `{ status: success, logs: [...] }` for k8s that is consistent with jobs.