### PR TITLE
[CCF-11868] Add scaleCount option to action deploy

### DIFF
--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -150,7 +150,8 @@ program
     .option('--environment [environment]', 'Environment')
     .option('--cmd [cmd]', 'Command to be executed')    //'["--daemon"]'
     .option('--environmentVariables [environmentVariables]', 'Docker container environment variables, only used for daemon action types')
-    .option('--push-docker', 'Push Docker image to the Cortex registry.')    
+    .option('--push-docker', 'Push Docker image to the Cortex registry.')
+    .option('--scaleCount [count]', 'Scale count', 'Scale count, only used for daemon action types')
     .action(withCompatibilityCheck((actionName, options) => {
         try {
             if (!options.kind && !options.docker) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-cli",
-  "version": "0.12.20",
+  "version": "0.13.0",
   "description": "Command line tool for CognitiveScale Cortex.",
   "main": "./bin/cortex.js",
   "scripts": {

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -54,7 +54,7 @@ module.exports = class Actions {
         });
     }
 
-    async deployAction(token, actionName, docker, kind, code, memory, vcpus, ttl, actionType, command, port, environment, environmentVariables, pushDocker) {
+    async deployAction(token, actionName, docker, kind, code, memory, vcpus, ttl, actionType, command, port, environment, environmentVariables, pushDocker, scaleCount) {
         let endpoint = `${this.endpointV3}`;
         if (actionType) {
             endpoint = `${endpoint}?actionType=${actionType}`;
@@ -83,6 +83,7 @@ module.exports = class Actions {
         if (port) req.field('port', port);
         if (environment) req.field('environment', environment);
         if (environmentVariables) req.field('environmentVariables', environmentVariables);
+        if (_.isFinite(scaleCount)) req.field('scaleCount', scaleCount);
 
         return req.then((res) => {
             if (res.ok) {

--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -112,9 +112,10 @@ module.exports.DeployActionCommand = class {
         const environment = options.environment;
         const environmentVariables = options.environmentVariables;
         const pushDocker = options.pushDocker;
+        const scaleCount = parseInt(options.scaleCount);
 
         const actions = new Actions(profile.url);
-        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, vcpus, ttl, actionType, cmd, port, environment, environmentVariables, pushDocker)
+        actions.deployAction(profile.token, actionName, dockerImage, kind, code, memory, vcpus, ttl, actionType, cmd, port, environment, environmentVariables, pushDocker, scaleCount)
             .then((response) => {
                 if (response.success) {
                     printSuccess(JSON.stringify(response.message, null, 2), options);


### PR DESCRIPTION
Followed the same pattern as `memory` and `vcpus` (simple `_.isFinite` check, no validation of min/max, that it's only allowed for actionType daemon, etc.).  Too much of a PITA with commander.js to do anything fancier.