### PR TITLE
[CCF-12231] Fix endpoint specification for deleting a profile

### DIFF
--- a/src/client/graph.js
+++ b/src/client/graph.js
@@ -122,10 +122,11 @@ class Graph {
     }
 
     deleteProfile(token, profileId, schemaName) {
-        debug('deleteProfile(%s) => DELETE %s', profileId, this.endpoints.profiles);
+        const endpoint = `${this.endpoints.profiles}/${profileId}`;
+        debug('deleteProfile(%s) => DELETE %s', profileId, endpoint);
 
         const req = request
-            .delete(this.endpoints.profiles)
+            .delete(endpoint)
             .set('Authorization', `Bearer ${token}`)
             .set('x-cortex-proxy-notify', true);
 


### PR DESCRIPTION
The DELETE route in the graph service is `.../profiles/*` and requires a profile ID.  The CLI was using `.../profiles`, which is not the same route and is rejected by Express.

I'll do `npm version patch` in the develop branch after this is merged to bump the version.