### PR TITLE
Fix api end

### DIFF
--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -160,8 +160,7 @@ module.exports.InvokeActionCommand = class {
         if (options.vcpus)
             params.properties['vcpus'] =parseFloat(options.vcpus);
 
-        // Set the API Endpoint and Token if not specified
-        // if (!params.apiEndpoint) params.apiEndpoint = profile.url;
+        // Set Token if not specified
         if (!params.token) params.token = profile.token;
 
         debug('params: %o', params);

--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -161,7 +161,7 @@ module.exports.InvokeActionCommand = class {
             params.properties['vcpus'] =parseFloat(options.vcpus);
 
         // Set the API Endpoint and Token if not specified
-        if (!params.apiEndpoint) params.apiEndpoint = profile.url;
+        // if (!params.apiEndpoint) params.apiEndpoint = profile.url;
         if (!params.token) params.token = profile.token;
 
         debug('params: %o', params);


### PR DESCRIPTION
Remove odd behavior invoking agents,  the api endpoint is provided from the cli's profile and NOT using the internal cluster address.  This has unintended consequences when using proxies/etc..