### PR TITLE
skill-generate  templates v6 updates

### DIFF
--- a/src/commands/assets/templates/skill/daemon/README.md
+++ b/src/commands/assets/templates/skill/daemon/README.md
@@ -1,4 +1,4 @@
-### Daemon Skill
+### Daemon Skill type
 
 Long running Cortex skill serving REST API requests
 
@@ -36,7 +36,7 @@ Note:
   --port '5000'  \
   --project <Project Name>
   ```
-6. Modify the `skills.yaml` file.
+6. Modify the `skill.yaml` file.
 7. Save/deploy the Skill.
   ```
   cortex skills save -y skill.yaml --project <Project Name>

--- a/src/commands/assets/templates/skill/daemon/README.md
+++ b/src/commands/assets/templates/skill/daemon/README.md
@@ -2,27 +2,48 @@
 
 Long running Cortex skill serving REST API requests
 
-#### Files generated:
+Note:
+> This project assumes a `fast api server` with one endpoint `/invoke` that is run with the Uvicorn python3 binary; you may change to another framework or language.
+
+
+#### Files generated
 * `skill.yaml` Skill definition
 * `main.py` Python3 code serving the daemon API
 * `requirements.txt` Python3 libraries dependencies
 * `Dockerfile` to build Docker image for this skill
 
-#### Next Steps:
-* Add input/output parameters and properties in skill.yaml as per requirement 
-* Update `main.py` with the business logic this skill will implement.
-* Add required libraries to `requirements.txt` 
-* Make changes to Dockerfile if required 
+#### Steps
+1. Modify the main executable (`main.py` by default) run by the action image's entrypoint/command to handle the action's custom logic.
+2. Modify the `requirements.txt` file to provide packages or libraries that the action requires.
+3. Build the docker image (uses the `main.py` file)
+  ```
+  docker build -t <image-name>:<version> .
+  ```
+4. Push the docker image to a registry that is connected to your Kubernetes cluster.
+  ```
+  docker push <image-name>:<version>
+  ```
 
-Note:
-> This is a Fast API/Uvicorn based Python3 project, feel free to change to other framework or language as per the need
+  **(Optionally) Retag an image**
+  ```
+  docker tag <existing-image-name>:<existing-version> <new-image-name>:<new-version>
+  ```
+5. Deploy the action.
+  ```
+  cortex actions deploy <SKILL_NAME> \
+  --actionType daemon \
+  --docker <DOCKER_IMAGE> \
+  --port '5000'  \
+  --project <Project Name>
+  ```
+6. Modify the `skills.yaml` file.
+7. Save/deploy the Skill.
+  ```
+  cortex skills save -y skill.yaml --project <Project Name>
+  ```
 
-#### Deployment Steps
-* Build the docker image and push to registry accessible to Cortex DCI
-    ```bash
-        docker build -t <SKILL_NAME>:<DOCKER_IMAGE_TAG>  -f Dockerfile .
-        docker tag <SKILL_NAME>:<DOCKER_IMAGE_TAG> <DOCKER_IMAGE_URL_IN_REGISTRY>
-        docker push <DOCKER_IMAGE_URL_IN_REGISTRY>
-    ```
-* Save Cortex Action `cortex actions deploy <SKILL_NAME> --actionType daemon --docker <DOCKER_IMAGE> --port '5000'  --project <Project Name>`
-* Deploy this Skill `cortex skills save -y skill.yaml --project <Project Name>`
+   The Skill is added to the Cortex Fabric catalog and is available for selection when building interventions or Agents.
+
+   Skills that are deployed may be invoked (run) either independently or within an agent.
+
+For more details about how to build skills go to [Cortex Fabric Documentation - Build Skills - Define Skills](https://cognitivescale.github.io/cortex-fabric/docs/build-skills/define-skills)

--- a/src/commands/assets/templates/skill/external-api/README.md
+++ b/src/commands/assets/templates/skill/external-api/README.md
@@ -2,7 +2,11 @@
 
 This Cortex skill is to wrap an external REST API as a skill
 
-Update `skill.yaml` with `HTTP Method`, `URL`, `Path` and `headers` as per the targeted external API
+1. Update `skill.yaml` with `HTTP Method`, `URL`, `Path` and `headers` per the targeted external API
+2. Deploy either Skill `cortex skills save -y skill.yaml --project <Project Name>`
 
-#### Deployment Steps:
-* Deploy this Skill `cortex skills save -y skill.yaml --project <Project Name>`
+The Skill is added to the Cortex Fabric catalog and is available for selection when building interventions or Agents.
+
+Skills that are deployed may be invoked (run) either independently or within an agent.
+
+For more details about how to build skills go to [Cortex Fabric Documentation - Build Skills - Define Skills](https://cognitivescale.github.io/cortex-fabric/docs/build-skills/define-skills)

--- a/src/commands/assets/templates/skill/external-api/README.md
+++ b/src/commands/assets/templates/skill/external-api/README.md
@@ -1,9 +1,9 @@
-### External API Skill
+### External API Skill type
 
-This Cortex skill is to wrap an external REST API as a skill
+This skill type allows users to wrap an external REST API as a Cortex Fabric Skill.
 
 1. Update `skill.yaml` with `HTTP Method`, `URL`, `Path` and `headers` per the targeted external API
-2. Deploy either Skill `cortex skills save -y skill.yaml --project <Project Name>`
+2. Deploy the Skill `cortex skills save -y skill.yaml --project <Project Name>`
 
 The Skill is added to the Cortex Fabric catalog and is available for selection when building interventions or Agents.
 

--- a/src/commands/assets/templates/skill/job/README.md
+++ b/src/commands/assets/templates/skill/job/README.md
@@ -1,6 +1,6 @@
-### Daemon Skill
+### Job Skill type
 
-Background job running Cortex skill
+Cortex skill that runs a background job.
 
 #### Files generated
 * `skill.yaml` Skill definition
@@ -32,7 +32,7 @@ Background job running Cortex skill
   --port '5000'  \
   --project <Project Name>
   ```
-6. Modify the `skills.yaml` file.
+6. Modify the `skill.yaml` file.
 7. Save/deploy the Skill.
   ```
   cortex skills save -y skill.yaml --project <Project Name>

--- a/src/commands/assets/templates/skill/job/README.md
+++ b/src/commands/assets/templates/skill/job/README.md
@@ -2,24 +2,44 @@
 
 Background job running Cortex skill
 
-#### Files generated:
+#### Files generated
 * `skill.yaml` Skill definition
 * `main.py` Python3 code implementing job's business logic
 * `requirements.txt` Python3 libraries dependencies
 * `Dockerfile` to build Docker image for this skill
 
-#### Next Steps:
-* Add input/output parameters and properties in skill.yaml as per requirement 
-* Update `main.py` with the business logic this skill will implement.
-* Add required libraries to `requirements.txt` 
-* Make changes to Dockerfile if required 
+#### Steps
+1. Modify the main executable (`main.py` by default) run by the action image's entrypoint/command to handle the action's custom logic.
+2. Modify the `requirements.txt` file to provide packages or libraries that the action requires.
+3. Build the docker image (uses the `main.py` file)
+  ```
+  docker build -t <image-name>:<version> .
+  ```
+4. Push the docker image to a registry that is connected to your Kubernetes cluster.
+  ```
+  docker push <image-name>:<version>
+  ```
 
-#### Deployment Steps
-* Build the docker image and push to registry accessible to Cortex DCI
-    ```bash
-        docker build -t <SKILL_NAME>:<DOCKER_IMAGE_TAG>  -f Dockerfile .
-        docker tag <SKILL_NAME>:<DOCKER_IMAGE_TAG> <DOCKER_IMAGE_URL_IN_REGISTRY>
-        docker push <DOCKER_IMAGE_URL_IN_REGISTRY>
-    ```
-* Save Cortex Action `cortex actions deploy <SKILL_NAME> --actionType job --docker <DOCKER_IMAGE> --cmd '["python", "/app/main.py"]'  --project <Project Name>`
-* Deploy this Skill `cortex skills save -y skill.yaml --project <Project Name>`
+  **(Optionally) Retag an image**
+  ```
+  docker tag <existing-image-name>:<existing-version> <new-image-name>:<new-version>
+  ```
+5. Deploy the action.
+  ```
+  cortex actions deploy <SKILL_NAME> \
+  --actionType daemon \
+  --docker <DOCKER_IMAGE> \
+  --port '5000'  \
+  --project <Project Name>
+  ```
+6. Modify the `skills.yaml` file.
+7. Save/deploy the Skill.
+  ```
+  cortex skills save -y skill.yaml --project <Project Name>
+  ```
+
+   The Skill is added to the Cortex Fabric catalog and is available for selection when building interventions or Agents.
+
+   Skills that are deployed may be invoked (run) either independently or within an agent.
+
+For more details about how to build skills go to [Cortex Fabric Documentation - Build Skills - Define Skills](https://cognitivescale.github.io/cortex-fabric/docs/build-skills/define-skills)


### PR DESCRIPTION
Revised the skill generate template readmes  to match (an abbreviated version) the v6 build-skills docs and to add links to those docs.
https://cognitivescale.atlassian.net/browse/FAB-1010

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [x] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [x] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
