### PR TITLE
Fix docs gen

### DIFF
--- a/generate_docs.js
+++ b/generate_docs.js
@@ -52,6 +52,7 @@ Interface (Cortex CLI). See [CLI](getting-started/use-cli.md) for
 help getting started using the CLI.
 ## Notation
 The following table describes the common notation used in this reference guide.
+
 | Notation | Description  | Example                                       |
 | -------- | -----------  | -------                                       |
 | \`< >\`    | Required     | \`<value>\` denotes a required value.      |

--- a/generate_docs.js
+++ b/generate_docs.js
@@ -13,8 +13,8 @@ const rootJson = require(`${sourcedir}/cortex.json`)
 
 // replace /n/t with HTML equivs
 const cleanString = (s) => s
-    .replace(/\n/g, '<br />')
-    .replace(/\t/g, 'nbsp;nbsp;')
+    .replace(/\n/g, '')
+    .replace(/\t/g, '')
     .replace(/</g,'`<')
     .replace(/>/g,'>`')
 


### PR DESCRIPTION
There may be a better way to fix this, but with this change, when you generate the docs using ` ./generate_docs.sh`, you don't have to make any changes to the `cortex-cli-docs.md` output before copying it to the cortex-fabric docs for use in the docusaurus site.

@jgielstra-cs - please feel free to tweak this if it doesn't make sense the way I did it. Thanks!

The main difference is below.

Before the change, `br`s in this section were inserted in code brackets (i.e. they would print out as `<br /` rather than inserting a break) and there were a bunch of `nbsp`s that were printed out as text, not as actual spaces. 

**Before:**
![image](https://user-images.githubusercontent.com/24549063/105867699-fee66580-5fba-11eb-930a-e2af3e5bb80a.png)

**After:**
![image](https://user-images.githubusercontent.com/24549063/105867722-04dc4680-5fbb-11eb-8900-7cc424cfd835.png)

And it looks fine when built in the docs now. The extra breaks and spaces weren't needed.

![image](https://user-images.githubusercontent.com/24549063/105868786-27229400-5fbc-11eb-9b96-422f49e639a3.png)


