### PR TITLE
[FAB-1154] Fix node-plop template files glob pattern for Windows

### DIFF
--- a/src/commands/plopfile.js
+++ b/src/commands/plopfile.js
@@ -24,7 +24,7 @@ module.exports = (plop) => {
                 // Handlebars template used to generate content of project files
                 base: 'assets/templates/skill/{{dashCase type}}',
                 // Note: Unlike other files, this doesn't strip hbs extension from Dockerfile, because this doesn't have any extension. So not using hbs extension in Dockerfile and picking all files in directory
-                templateFiles: path.join('assets/templates/skill/{{dashCase type}}', '**/*'),
+                templateFiles: 'assets/templates/skill/{{dashCase type}}/**/*',
                 abortOnFail: true,
                 // Must not overwrite files with scaffolding template if already exists
                 // force: true,


### PR DESCRIPTION
Can't explain why the old templateFiles specification worked on macOS but not on Windows.  Perhaps NodeJS path.join behavior on windows doesn't like {{}}?  This change empirically fixes things on my Win10 VM, and it continues to work correctly on macOS.