### PR TITLE
When using the --users option of roles assign command ensure there are no empty strings

### DIFF
--- a/bin/cortex-roles.js
+++ b/bin/cortex-roles.js
@@ -19,6 +19,7 @@ const chalk = require('chalk');
 const program = require('../src/commander');
 
 const { withCompatibilityCheck } = require('../src/compatibility');
+const { nonEmptyStringParser } = require('../src/parsers');
 
 const {
     ExternalGroupAssignCommand,
@@ -120,7 +121,7 @@ program.command('assign <role>')
     .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .requiredOption('--users <users...>', 'Users to add/remove on role')
+    .requiredOption('--users <users...>', 'Users to add/remove on role', nonEmptyStringParser('user names must not be empty'))
     .option('--delete', 'Unassign users from role')
     .action(withCompatibilityCheck((role, options) => {
         try {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Cognitive Scale, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash');
+const program = require('./commander');
+
+function nonEmptyStringParser(message = 'empty string argument') {
+    return function parseNonEmptyString(arg) {
+        if (_.isEmpty(arg)) {
+            const error = `error: ${message}`;
+            console.error(error);
+            program._exit(1, 'cortex.invalidStringArgument', error);
+        }
+        return arg;
+    };
+}
+
+module.exports = {
+    nonEmptyStringParser,
+};


### PR DESCRIPTION
NOTE: I didn't want to add explicit empty-string-checks directly in the command action handlers, and I wanted the console output to look very similar to other command arg processing errors handled by commander.

The program.[required]option() method can take a parser function, so I hooked into that and had the parser log and exit just like commander does internally.