### PR TITLE
[FAB-1689] Previous implementation of empty string parser did not handle variadic params

### DIFF
--- a/bin/cortex-roles.js
+++ b/bin/cortex-roles.js
@@ -121,7 +121,7 @@ program.command('assign <role>')
     .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
-    .requiredOption('--users <users...>', 'Users to add/remove on role', nonEmptyStringParser('user names must not be empty'))
+    .requiredOption('--users <users...>', 'Users to add/remove on role', nonEmptyStringParser({ message: 'user names must not be empty', variadic: true }))
     .option('--delete', 'Unassign users from role')
     .action(withCompatibilityCheck((role, options) => {
         try {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -17,14 +17,21 @@
 const _ = require('lodash');
 const program = require('./commander');
 
-function nonEmptyStringParser(message = 'empty string argument') {
-    return function parseNonEmptyString(arg) {
-        if (_.isEmpty(arg)) {
+function nonEmptyStringParser(opts) {
+    const { message = 'empty string argument', variadic = false } = opts;
+    return function parseNonEmptyString(value, oldValue) {
+        if (_.isEmpty(value)) {
             const error = `error: ${message}`;
             console.error(error);
             program._exit(1, 'cortex.invalidStringArgument', error);
         }
-        return arg;
+        if (variadic) {
+            if (!Array.isArray(oldValue)) {
+                return [value];
+            }
+            return oldValue.concat(value);
+        }
+        return value;
     };
 }
 


### PR DESCRIPTION
This is an alternative to https://github.com/CognitiveScale/cortex-cli/pull/319, and fixes my previous implementation of the empty string parser as it was intended to work.

Note: commander is always presenting each individual username to the parser, but the internal codepath in commander **only** calls a provided parser, and does **not** perform the array build-up.  (Behavior is "provided parser XOR regular/other handling").  See https://github.com/tj/commander.js/blob/release/6.x/index.js#L536

This PR changes the parser to take an additional `variadic` option, and performs the array build-up as linked above when true.  (Super lame the parser is not provided the Option, which prevents the parser from automatically determining variadic or not :-/ ).