### PR TITLE
Fixing docker-login command to work with fabric endpoints

### DIFF
--- a/bin/cortex-configure.js
+++ b/bin/cortex-configure.js
@@ -47,13 +47,10 @@ program
     .option('--profile [profile]', 'The profile to use')
     .option('--project [project]', 'The project to use')
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
-    .action(() => {
+    .option('--ttl [time]', 'The amount of time for this login to remain active (ex. "1d")', "1d")
+    .action((options) => {
         try {
-            new GetAccessToken(program).execute({
-                profile: program.profile,
-                project: program.project,
-                color: program.color,
-            });
+            new GetAccessToken(program).execute(options);
         } catch (err) {
             console.error(chalk.red(err.message));
         }

--- a/bin/cortex-docker.js
+++ b/bin/cortex-docker.js
@@ -35,7 +35,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--project [project]', 'The project to use')
-    .option('--ttl [time]', 'The amount of time for this login to remain active (ex. "14d")')
+    .option('--ttl [time]', 'The amount of time for this login to remain active (ex. "14d")', "14d")
     .action(withCompatibilityCheck((options) => {
         try {
             new DockerLoginCommand(program).execute(options);

--- a/bin/cortex-docker.js
+++ b/bin/cortex-docker.js
@@ -35,6 +35,7 @@ program
     .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
     .option('--profile [profile]', 'The profile to use')
     .option('--project [project]', 'The project to use')
+    .option('--ttl [time]', 'The amount of time for this login to remain active (ex. "14d")')
     .action(withCompatibilityCheck((options) => {
         try {
             new DockerLoginCommand(program).execute(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4501,6 +4501,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -4634,6 +4639,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.19.0",
@@ -5871,6 +5881,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "plop": "2.7.4",
     "semver": "7.1.3",
     "tty-table": "4.1.1",
-    "url-join": "4.0.1"
+    "url-join": "4.0.1",
+    "url-parse": "1.5.1"
   },
   "devDependencies": {
     "chai": "4.2.0",

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -162,8 +162,9 @@ module.exports.GetAccessToken = class {
 
     execute(options) {
         const profile = loadProfile(options.profile);
+        const ttl = options.ttl || '1d';
         debug('%s.getAccesToken', profile.name);
-        const jwt = generateJwt(profile, '1d');
+        const jwt = generateJwt(profile, ttl);
         return printSuccess(jwt, options);
     }
 };


### PR DESCRIPTION
 - currently does a bit of string replace hackery to figure out the private-registry url, this can be fixed once the new info endpoint is available
 - default ttl of token created for docker login is set to 14d but can be overridden (for long lived kube secrets.. not really reliable though if the JWK changes)

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
