### PR TITLE
FAB-1699: commands for creating/listing/deleting service users

### DIFF
--- a/bin/cortex-users.js
+++ b/bin/cortex-users.js
@@ -25,6 +25,7 @@ const {
     UserDescribeCommand,
     UserGrantCommand,
     UserCreateCommand,
+    UserListCommand,
 } = require('../src/commands/users');
 
 program.description('Work with Cortex User');
@@ -87,6 +88,19 @@ program.command('create <user>')
     .action(withCompatibilityCheck((user, options) => {
         try {
             new UserCreateCommand(program).execute(user, options);
+        } catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+program.command('list')
+    .description('Lists all service users created within Cortex')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .action(withCompatibilityCheck((options) => {
+        try {
+            new UserListCommand(program).execute(options);
         } catch (err) {
             console.error(chalk.red(err.message));
         }

--- a/bin/cortex-users.js
+++ b/bin/cortex-users.js
@@ -26,6 +26,7 @@ const {
     UserGrantCommand,
     UserCreateCommand,
     UserListCommand,
+    UserDeleteCommand,
 } = require('../src/commands/users');
 
 program.description('Work with Cortex User');
@@ -75,6 +76,19 @@ program.command('project <project>')
     .action(withCompatibilityCheck((project, options) => {
         try {
             new UserProjectAssignCommand(program).execute(project, options);
+        } catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+program.command('delete <user>')
+    .description('Deletes a service user and disables any existing tokens created by the user')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .action(withCompatibilityCheck((user, options) => {
+        try {
+            new UserDeleteCommand(program).execute(user, options);
         } catch (err) {
             console.error(chalk.red(err.message));
         }

--- a/bin/cortex-users.js
+++ b/bin/cortex-users.js
@@ -24,6 +24,7 @@ const {
     UserProjectAssignCommand,
     UserDescribeCommand,
     UserGrantCommand,
+    UserCreateCommand,
 } = require('../src/commands/users');
 
 program.description('Work with Cortex User');
@@ -73,6 +74,19 @@ program.command('project <project>')
     .action(withCompatibilityCheck((project, options) => {
         try {
             new UserProjectAssignCommand(program).execute(project, options);
+        } catch (err) {
+            console.error(chalk.red(err.message));
+        }
+    }));
+
+program.command('create <user>')
+    .description('Creates a service user (with no assigned roles/grants) that can authenticate with and call Fabric API\'s')
+    .option('--no-compat', 'Ignore API compatibility checks')
+    .option('--color [on/off]', 'Turn on/off colors for JSON output.', 'on')
+    .option('--profile [profile]', 'The profile to use')
+    .action(withCompatibilityCheck((user, options) => {
+        try {
+            new UserCreateCommand(program).execute(user, options);
         } catch (err) {
             console.error(chalk.red(err.message));
         }

--- a/src/client/users.js
+++ b/src/client/users.js
@@ -54,6 +54,18 @@ module.exports = class Users {
             .catch(err => constructError(err));
     }
 
+    deleteServiceUser(token, user) {
+        const endpoint = `${this.endpoint}/accounts/service/${user}`;
+        debug('createServiceUser => %s', endpoint);
+        return got
+            .delete(endpoint, {
+                headers: { Authorization: `Bearer ${token}` },
+                'user-agent': getUserAgent(),
+            }).json()
+            .then(res => ({ success: true, result: res }))
+            .catch(err => constructError(err));
+    }
+
     listServiceUsers(token) {
         const endpoint = `${this.endpoint}/accounts/service`;
         debug('createServiceUser => %s', endpoint);

--- a/src/client/users.js
+++ b/src/client/users.js
@@ -54,6 +54,18 @@ module.exports = class Users {
             .catch(err => constructError(err));
     }
 
+    listServiceUsers(token) {
+        const endpoint = `${this.endpoint}/accounts/service`;
+        debug('createServiceUser => %s', endpoint);
+        return got
+            .get(endpoint, {
+                headers: { Authorization: `Bearer ${token}` },
+                'user-agent': getUserAgent(),
+            }).json()
+            .then(res => ({ success: true, result: res }))
+            .catch(err => constructError(err));
+    }
+
     describeUser(token) {
         const endpoint = `${this.usersEndpoint}/${this.flags}`;
         debug('describeUser => %s', endpoint);

--- a/src/client/users.js
+++ b/src/client/users.js
@@ -42,6 +42,18 @@ module.exports = class Users {
         }
     }
 
+    createServiceUser(token, user) {
+        const endpoint = `${this.endpoint}/accounts/service/${user}`;
+        debug('createServiceUser => %s', endpoint);
+        return got
+            .post(endpoint, {
+                headers: { Authorization: `Bearer ${token}` },
+                'user-agent': getUserAgent(),
+            }).json()
+            .then(res => ({ success: true, result: res }))
+            .catch(err => constructError(err));
+    }
+
     describeUser(token) {
         const endpoint = `${this.usersEndpoint}/${this.flags}`;
         debug('describeUser => %s', endpoint);

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -62,6 +62,32 @@ module.exports.UserGrantCommand = class {
     }
 };
 
+module.exports.UserCreateCommand = class {
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(user, options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.createUser=%s', profile.name, user);
+
+        const flags = [];
+
+        const client = new Users(profile.url, user, flags);
+        client.createServiceUser(profile.token, user).then((response) => {
+            if (response.success) {
+                const result = filterObject(response.result, options);
+                printSuccess(JSON.stringify(result, null, 2), options);
+            } else {
+                printError(`Failed to create user ${user} : ${response.message}`, options);
+            }
+        })
+            .catch((err) => {
+                printError(`Failed to create user : ${err.status} ${err.message}`, options);
+            });
+    }
+};
+
 module.exports.UserDescribeCommand = class {
     constructor(program) {
         this.program = program;

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -71,9 +71,7 @@ module.exports.UserCreateCommand = class {
         const profile = loadProfile(options.profile);
         debug('%s.createUser=%s', profile.name, user);
 
-        const flags = [];
-
-        const client = new Users(profile.url, user, flags);
+        const client = new Users(profile.url, user);
         client.createServiceUser(profile.token, user).then((response) => {
             if (response.success) {
                 const result = filterObject(response.result, options);
@@ -84,6 +82,30 @@ module.exports.UserCreateCommand = class {
         })
             .catch((err) => {
                 printError(`Failed to create user : ${err.status} ${err.message}`, options);
+            });
+    }
+};
+
+module.exports.UserListCommand = class {
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.listUsers', profile.name);
+
+        const client = new Users(profile.url, 'self');
+        client.listServiceUsers(profile.token).then((response) => {
+            if (response.success) {
+                const result = filterObject(response.result, options);
+                printSuccess(JSON.stringify(result, null, 2), options);
+            } else {
+                printError(`Failed to list service users : ${response.message}`, options);
+            }
+        })
+            .catch((err) => {
+                printError(`Failed to list service users : ${err.status} ${err.message}`, options);
             });
     }
 };

--- a/src/commands/users.js
+++ b/src/commands/users.js
@@ -62,6 +62,30 @@ module.exports.UserGrantCommand = class {
     }
 };
 
+module.exports.UserDeleteCommand = class {
+    constructor(program) {
+        this.program = program;
+    }
+
+    execute(user, options) {
+        const profile = loadProfile(options.profile);
+        debug('%s.deleteServiceUser=%s', profile.name, user);
+
+        const client = new Users(profile.url, user);
+        client.deleteServiceUser(profile.token, user).then((response) => {
+            if (response.success) {
+                const result = filterObject(response.result, options);
+                printSuccess(JSON.stringify(result, null, 2), options);
+            } else {
+                printError(`Failed to delete user ${user} : ${response.message}`, options);
+            }
+        })
+            .catch((err) => {
+                printError(`Failed to delete user : ${err.status} ${err.message}`, options);
+            });
+    }
+};
+
 module.exports.UserCreateCommand = class {
     constructor(program) {
         this.program = program;
@@ -69,7 +93,7 @@ module.exports.UserCreateCommand = class {
 
     execute(user, options) {
         const profile = loadProfile(options.profile);
-        debug('%s.createUser=%s', profile.name, user);
+        debug('%s.createServiceUser=%s', profile.name, user);
 
         const client = new Users(profile.url, user);
         client.createServiceUser(profile.token, user).then((response) => {
@@ -93,7 +117,7 @@ module.exports.UserListCommand = class {
 
     execute(options) {
         const profile = loadProfile(options.profile);
-        debug('%s.listUsers', profile.name);
+        debug('%s.listServiceUsers', profile.name);
 
         const client = new Users(profile.url, 'self');
         client.listServiceUsers(profile.token).then((response) => {


### PR DESCRIPTION
Wasn't sure if the `users` command was the right place to add these commands.. figured typical users would make a new service user (NOTE: trying to keep the verbiage different from being confused with k8s ServiceAccounts) and then immediately assign roles/grants to them?


# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
