### PR TITLE
encoding not required for request body params

### DIFF
--- a/src/client/assessments.js
+++ b/src/client/assessments.js
@@ -80,11 +80,11 @@ module.exports = class Assessments {
                 headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
                 'user-agent': getUserAgent(),
                 body: JSON.stringify({
-                    name: encodeURIComponent(name),
+                    name,
                     title,
                     description,
                     scope,
-                    componentName: encodeURIComponent(componentName),
+                    componentName,
                     componentTypes,
                     overwrite,
                 }),


### PR DESCRIPTION
encoding not required for request body params and null values will be converted to "undefined" cause them so save as valid value for required fields
