### PR TITLE
reordering the way we find request error status codes to avoid fetchi…

### DIFF
--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -45,8 +45,10 @@ module.exports.constructError = (error) => {
     } catch (e) {
         // Guess it wasn't JSON!
     }
+    // todo make figuring out the status code more consistent? this might be a holdover from request vs got?
+    const status = _.get(errResp, 'statusCode') || error.code || error.status || '';
     return {
- success: false, message: errorText, details, status: error.status || error.code || _.get(errResp, 'statusCode') || '',
+ success: false, message: errorText, details, status,
 };
 };
 


### PR DESCRIPTION
…ng the incorrect code of the httpError object itself (returning ERR_NON_2XX_3XX_RESPONSE)

tests were failing to check these messages (granted its a hardcoded string assertion which is bad but that's a different topic)
```
Failed to describe action: ERR_NON_2XX_3XX_RESPONSE Action with name blah not found
```