### PR TITLE
add messages onto options help that jobTimeout is only valid for jobs…

### DIFF
--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -120,11 +120,11 @@ program
     .option('--cmd [cmd]', 'Command to be executed') // '["--daemon"]'
     .option('--image, --docker [image]', 'Docker image to use as the runner')
     .option('--environmentVariables [environmentVariables]', 'Docker container environment variables, only used for daemon action types')
-    .option('--jobTimeout [jobTimeout]', 'Job Timeout in seconds, this will marked the job as FAILED (default: no timeout)')
+    .option('--jobTimeout [jobTimeout]', 'Job Timeout in seconds until the job is marked as FAILED (default: no timeout), only used for job action types')
     .option('-k, --k8sResource [file...]', 'Additional kubernetes resources deployed and owned by the skill, provide as last option specified or end list of files with "--"')
     .option('--no-compat', 'Ignore API compatibility checks')
     .option('--podspec [podspec]', 'A file containing either a JSON or YAML formatted pod spec to merge with the action definition, used for specifying resources (like memory, ephemeral storage, CPUs, and GPUs) and tolerations (like allowing pods to be scheduled on tainted nodes).')
-    .option('--port [port]', 'Docker port') // '9091'
+    .option('--port [port]', 'Docker port, only used for daemon action types') // '9091'
     .option('--profile [profile]', 'The profile to use')
     .option('--project [project]', 'The project to use')
     .option('--scaleCount [count]', 'Scale count, only used for daemon action types')

--- a/src/commands/actions.js
+++ b/src/commands/actions.js
@@ -137,6 +137,9 @@ module.exports.DeployActionCommand = class {
                 actionInst.command = options.cmd;
             }
             if (options.port) {
+                if (actionInst.type === 'job') {
+                    printError('--port not valid on job action types');
+                }
                 if (!isNumeric(options.port)) {
                     printError('--port must be a number', options);
                 }
@@ -156,6 +159,9 @@ module.exports.DeployActionCommand = class {
             }
 
             if (options.jobTimeout) {
+                if (actionInst.type === 'daemon') {
+                    printError('--jobTimeout not valid on daemon action types');
+                }
                 if (!isNumeric(options.jobTimeout)) {
                     printError('--jobTimeout must be a number', options);
                 }


### PR DESCRIPTION
… and port is only valid on daemon actions

also print error if either option is provided for the wrong type

More info and example outputs in this [comment](https://cognitivescale.atlassian.net/browse/FAB-2639?focusedCommentId=95612).

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
