### PR TITLE
compatibility issue found in dci-qa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,29 +1363,29 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
+        "cache-base": "2.0.2",
         "class-utils": "^0.3.5",
         "component-emitter": "^1.2.1",
         "define-property": "^1.0.0",
         "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
+        "mixin-deep": "2.0.1",
         "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "cache-base": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-2.0.2.tgz",
+          "integrity": "sha512-qU8SRzqRQwZAfk9iwBfcr2fod7LuugGE+zdGzejudnWia0cIMA+sizwpJmL8JNxuvdwUE+RAvstFG6l3FaRIfA==",
           "requires": {
-            "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
+            "unset-value": "^1.0.0",
             "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
+            "collection-visit": "^1.0.0",
             "set-value": "^2.0.0",
+            "isobject": "^3.0.1",
+            "get-value": "^2.0.6",
             "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "union-value": "^1.0.0"
           }
         },
         "define-property": {
@@ -1431,9 +1431,9 @@
           }
         },
         "mixin-deep": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-2.0.1.tgz",
+          "integrity": "sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA==",
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"

--- a/src/config.js
+++ b/src/config.js
@@ -35,7 +35,8 @@ async function generateJwt(profile, expiresIn = '2m') {
     } = profile;
     const jwtSigner = await jose.importJWK(jwk, 'Ed25519');
     const infoClient = new Info(profile.url);
-    const { serverTs } = await infoClient.getInfo();
+    let { serverTs } = await infoClient.getInfo();
+    if (_.isNull(serverTs)) serverTs = Date.now();
     return new jose.SignJWT({})
         .setProtectedHeader({ alg: 'EdDSA', kid: jwk.kid })
         .setSubject(username)

--- a/src/config.js
+++ b/src/config.js
@@ -35,8 +35,8 @@ async function generateJwt(profile, expiresIn = '2m') {
     } = profile;
     const jwtSigner = await jose.importJWK(jwk, 'Ed25519');
     const infoClient = new Info(profile.url);
-    let { serverTs } = await infoClient.getInfo();
-    if (_.isNull(serverTs)) serverTs = Date.now();
+    const infoResp = await infoClient.getInfo();
+    const serverTs = _.get(infoResp, 'serverTs', Date.now());
     return new jose.SignJWT({})
         .setProtectedHeader({ alg: 'EdDSA', kid: jwk.kid })
         .setSubject(username)


### PR DESCRIPTION
This was introduced recently while trying to fix some of our [timing issues when generating tokens](https://github.com/CognitiveScale/cortex-cli/pull/481).

use system time as a default if info endpoint response does not include the server timestamp
also bumped packages from npm audit scan

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
