### PR TITLE
Remove JSON.stringify from task log output

### DIFF
--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -92,7 +92,7 @@ module.exports.TaskLogsCommand = class TaskLogsCommand {
         try {
             const response = await tasks.taskLogs(options.project || profile.project, profile.token, taskName, options.verbose);
             if (response.success) {
-                return printSuccess(JSON.stringify(response.logs), options);
+                return printSuccess(response.logs, options);
             }
             return printError(`Failed to List Task Logs ${taskName}: ${response.message}`, options);
         } catch (err) {


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
