### PR TITLE
Update build script to publish beta tagged versions of the cli to npm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,18 +26,21 @@ function local_docker(){
 
 # This runs inside a linux docker container
 function docker_build(){
+    echo ${VERSION} > version.txt
+    if [[ ${BRANCH} != "main" ]]; then
+      sed  -i '/version/s/.*,/'"  \"version\": \"$VERSION\",/" package.json
+    fi
     npm ci --unsafe-perm --userconfig=/root/.npmrc
     npm test
-    echo ${VERSION} > version.txt
     ./generate_docs.sh
     BRANCH=$(git symbolic-ref --short -q HEAD)
     npm prune --production
     if [[ ${BRANCH} = "main" ]]; then
 #        TODO this should maybe be done as part of the gocd pipeline?.. or maybe get in the habit of pushing alpha versions to npm just like we do for cortex-python?..
-        npm publish --registry=https://registry.npmjs.org/
+        npm publish --tag latest --registry=https://registry.npmjs.org/
     elif [[ ${BRANCH} = "develop" ]]; then
-        npm config set always-auth true
-#        npm publish --tag "${BRANCH}" --registry=https://cognitivescale.jfrog.io/artifactory/api/npm/npm-local/
+#        npm config set always-auth true
+        npm publish --tag beta --registry=https://registry.npmjs.org/
     fi
 
     npm pack cortex-cli


### PR DESCRIPTION
Was looking at https://kevinkreuzer.medium.com/publishing-a-beta-or-alpha-version-to-npm-46035b630dd7 and wanted to try using tags.. we already have the ability to publish alpha versions of cortex-python by merging into the `staging` branch and wanted similar functionality here, hopefully this helps iron out any issues with installing the cli prior to the actual release.

publish latest tag off main build and beta tag off develop build to publish npm

update package.json with `git describe` version when not building the main branch

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
