### PR TITLE
Misc fallout from integration tests

### DIFF
--- a/bin/cortex-actions.js
+++ b/bin/cortex-actions.js
@@ -92,7 +92,7 @@ program
 
 // Deploy Action
 program
-    .command('deploy <actionDefinition>')
+    .command('deploy [actionDefinition]')
     .alias('save')
     .description('Deploy an action')
     .storeOptionsAsProperties(false)


### PR DESCRIPTION
mark actionDefinition as optional and any other small issues that pop up while fixing the integration tests.