### PR TITLE
renamed top level `verbose` option on cortex.js to `debug` as it was …

### DIFF
--- a/bin/cortex-agents.js
+++ b/bin/cortex-agents.js
@@ -138,6 +138,7 @@ program
         }
     }));
 
+// Get activation
 program
     .command('get-activation <activationId>')
     .description('Get dataset or service activation')

--- a/bin/cortex.js
+++ b/bin/cortex.js
@@ -24,8 +24,8 @@ program.name('cortex');
 program
     .version(pkg.version, '-v, --version')
     .description('Cortex CLI')
-    .option('--verbose', 'Verbose output', false)
-    .on('option:verbose', () => { process.env.DEBUG = '*'; })
+    .option('--debug', 'Enables verbose output for debugging', false)
+    .on('option:debug', () => { process.env.DEBUG = '*'; })
     .command('actions <cmd>', 'Work with Cortex Actions')
     .command('agents <cmd>', 'Work with Cortex Agents')
     .command('assessments <cmd>', 'Work with Cortex Impact Assessments')


### PR DESCRIPTION
…conflicting with the existing option available on the `cortex agents get-activation` command

This was also what was causing the `dci-dev` pipeline to fail.

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
- [ ] Changes are backward compatible with older clusters
