### PR TITLE
FAB-4605 - Remove registry option for generate

### DIFF
--- a/bin/cortex-workspaces.js
+++ b/bin/cortex-workspaces.js
@@ -46,7 +46,6 @@ program
 
     program
     .command('generate [name] [destination]')
-    .option('--registry <registry>', 'Override the docker registry to publish to')
     .option('--color [boolean]', 'Turn on/off colors', 'true')
     .option('--notree', 'Do not display generated file tree', false)
     .option('--template <templateName>', 'Name of template to use')


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [x] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [x] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters

The registry option for generate is no longer used, because the CLI/IDE automatically substitute the active registry at publish time.

