### PR TITLE
Force node version to 16.15.0 as 16.15.1 breaks the audit-ci tool, mi…

### DIFF
--- a/c12e-ci.yml
+++ b/c12e-ci.yml
@@ -1,3 +1,3 @@
 builder:
-  image: node:16-bullseye
+  image: node:16.15.0-bullseye
   command: "./build.sh CI"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "dependencies": {
         "boolean": "3.2.0",
         "chalk": "4.1.2",
-        "cli-progress": "3.11.0",
+        "cli-progress": "3.11.1",
         "cli-table3": "0.6.2",
-        "commander": "9.2.0",
+        "commander": "9.3.0",
         "debug": "4.3.4",
-        "dockerode": "3.3.1",
+        "dockerode": "3.3.2",
         "find-package-json": "1.2.0",
         "form-data": "4.0.0",
         "get-stream": "6.0.1",
@@ -50,7 +50,7 @@
         "cortex": "bin/cortex.js"
       },
       "devDependencies": {
-        "audit-ci": "5.1.2",
+        "audit-ci": "6.3.0",
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
         "cross-env": "7.0.3",
@@ -61,7 +61,7 @@
         "is-ci": "3.0.1",
         "mocha": "9.2.2",
         "mocked-env": "1.3.5",
-        "nock": "13.2.4",
+        "nock": "13.2.6",
         "nyc": "15.1.0",
         "rewire": "6.0.0",
         "sinon": "11.1.2"
@@ -1080,24 +1080,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -1130,12 +1112,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/audit-ci": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-5.1.2.tgz",
-      "integrity": "sha512-FNBbo4ycoHxcS7ruNNkq3LB+fZ4UWDd0QUNAva7Ae/F/Y45BBA7ZfHPSr5Fr+tS2+eqSwxToeFRRnw2Tp2PE8Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-6.3.0.tgz",
+      "integrity": "sha512-rVCn4J7SUMQw2A21E3PPLzMz70A5RqWIx5BzvuU0iKeEGuuC6vGE00eeo4mFEnr439WdvI9i2lCXnmgABqLSeQ==",
       "dev": true,
       "dependencies": {
-        "array.prototype.flatmap": "^1.2.5",
         "cross-spawn": "^7.0.3",
         "escape-string-regexp": "^4.0.0",
         "event-stream": "4.0.1",
@@ -1143,13 +1124,40 @@
         "JSONStream": "^1.3.5",
         "readline-transform": "1.0.0",
         "semver": "^7.0.0",
-        "yargs": "^16.0.0"
+        "yargs": "^17.0.0"
       },
       "bin": {
-        "audit-ci": "lib/audit-ci.js"
+        "audit-ci": "dist/bin.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.9.0"
+      }
+    },
+    "node_modules/audit-ci/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/audit-ci/node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -1590,9 +1598,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.0.tgz",
-      "integrity": "sha512-ug+V4/Qy3+0jX9XkWPV/AwHD98RxKXqDpL37vJBOxQhD90qQ3rDqDKoFpef9se91iTUuOXKlyg2HUyHBo5lHsQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.1.tgz",
+      "integrity": "sha512-TTMA2LHrYaZeNMcgZGO10oYqj9hvd03pltNtVbu4ddeyDTHlYV7gWxsFiuvaQlgwMBFCv1TukcjiODWFlb16tQ==",
       "dependencies": {
         "string-width": "^4.2.3"
       },
@@ -1696,9 +1704,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
+      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -1986,9 +1994,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.1.tgz",
-      "integrity": "sha512-AS2mr8Lp122aa5n6d99HkuTNdRV1wkkhHwBdcnY6V0+28D3DSYwhxAk85/mM9XwD3RMliTxyr63iuvn5ZblFYQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.2.tgz",
+      "integrity": "sha512-oXN+1XVH2TeyE0Jj9Ci6Fim8ZIDxyqeJrkx9qhEOaRiA+nhLihKfd3M2L+Aqrj5C2ObPw8RVN2zPWvvk0x2dwg==",
       "dependencies": {
         "docker-modem": "^3.0.0",
         "tar-fs": "~2.0.1"
@@ -4154,12 +4162,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -4702,14 +4704,14 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
-      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "version": "13.2.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.6.tgz",
+      "integrity": "sha512-GbyeSwSEP0FYouzETZ0l/XNm5tNcDNcXJKw3LCAb+mx8bZSwg1wEEvdL0FAyg5TkBJYiWSCtw6ag4XfmBy60FA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       },
       "engines": {
@@ -7844,18 +7846,6 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "array.prototype.flatmap": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.0.tgz",
-      "integrity": "sha512-PZC9/8TKAIxcWKdyeb77EzULHPrIX/tIZebLJUQOMR1OwYosT8yggdfWScfTBCDj5utONvOuPQQumYsU2ULbkg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
     "asn1": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
@@ -7882,12 +7872,11 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "audit-ci": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-5.1.2.tgz",
-      "integrity": "sha512-FNBbo4ycoHxcS7ruNNkq3LB+fZ4UWDd0QUNAva7Ae/F/Y45BBA7ZfHPSr5Fr+tS2+eqSwxToeFRRnw2Tp2PE8Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-6.3.0.tgz",
+      "integrity": "sha512-rVCn4J7SUMQw2A21E3PPLzMz70A5RqWIx5BzvuU0iKeEGuuC6vGE00eeo4mFEnr439WdvI9i2lCXnmgABqLSeQ==",
       "dev": true,
       "requires": {
-        "array.prototype.flatmap": "^1.2.5",
         "cross-spawn": "^7.0.3",
         "escape-string-regexp": "^4.0.0",
         "event-stream": "4.0.1",
@@ -7895,7 +7884,30 @@
         "JSONStream": "^1.3.5",
         "readline-transform": "1.0.0",
         "semver": "^7.0.0",
-        "yargs": "^16.0.0"
+        "yargs": "^17.0.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
+        }
       }
     },
     "balanced-match": {
@@ -8200,9 +8212,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.0.tgz",
-      "integrity": "sha512-ug+V4/Qy3+0jX9XkWPV/AwHD98RxKXqDpL37vJBOxQhD90qQ3rDqDKoFpef9se91iTUuOXKlyg2HUyHBo5lHsQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.1.tgz",
+      "integrity": "sha512-TTMA2LHrYaZeNMcgZGO10oYqj9hvd03pltNtVbu4ddeyDTHlYV7gWxsFiuvaQlgwMBFCv1TukcjiODWFlb16tQ==",
       "requires": {
         "string-width": "^4.2.3"
       }
@@ -8277,9 +8289,9 @@
       }
     },
     "commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
+      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -8488,9 +8500,9 @@
       }
     },
     "dockerode": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.1.tgz",
-      "integrity": "sha512-AS2mr8Lp122aa5n6d99HkuTNdRV1wkkhHwBdcnY6V0+28D3DSYwhxAk85/mM9XwD3RMliTxyr63iuvn5ZblFYQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.2.tgz",
+      "integrity": "sha512-oXN+1XVH2TeyE0Jj9Ci6Fim8ZIDxyqeJrkx9qhEOaRiA+nhLihKfd3M2L+Aqrj5C2ObPw8RVN2zPWvvk0x2dwg==",
       "requires": {
         "docker-modem": "^3.0.0",
         "tar-fs": "~2.0.1"
@@ -10090,12 +10102,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-      "dev": true
-    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -10497,14 +10503,14 @@
       }
     },
     "nock": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.4.tgz",
-      "integrity": "sha512-8GPznwxcPNCH/h8B+XZcKjYPXnUV5clOKCjAqyjsiqA++MpNx9E9+t8YPp0MbThO+KauRo7aZJ1WuIZmOrT2Ug==",
+      "version": "13.2.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.6.tgz",
+      "integrity": "sha512-GbyeSwSEP0FYouzETZ0l/XNm5tNcDNcXJKw3LCAb+mx8bZSwg1wEEvdL0FAyg5TkBJYiWSCtw6ag4XfmBy60FA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash.set": "^4.3.2",
+        "lodash": "^4.17.21",
         "propagate": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
   "dependencies": {
     "boolean": "3.2.0",
     "chalk": "4.1.2",
-    "cli-progress": "3.11.0",
+    "cli-progress": "3.11.1",
     "cli-table3": "0.6.2",
-    "commander": "9.2.0",
+    "commander": "9.3.0",
     "debug": "4.3.4",
-    "dockerode": "3.3.1",
+    "dockerode": "3.3.2",
     "find-package-json": "1.2.0",
     "form-data": "4.0.0",
     "get-stream": "6.0.1",
@@ -79,7 +79,7 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "audit-ci": "5.1.2",
+    "audit-ci": "6.3.0",
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",
     "cross-env": "7.0.3",
@@ -90,7 +90,7 @@
     "is-ci": "3.0.1",
     "mocha": "9.2.2",
     "mocked-env": "1.3.5",
-    "nock": "13.2.4",
+    "nock": "13.2.6",
     "nyc": "15.1.0",
     "rewire": "6.0.0",
     "sinon": "11.1.2"


### PR DESCRIPTION
…nor version bumps

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
- [ ] Changes are backward compatible with older clusters
