### PR TITLE
Makes --notree work just like --color

### DIFF
--- a/bin/cortex-workspaces.js
+++ b/bin/cortex-workspaces.js
@@ -47,7 +47,7 @@ program
     program
     .command('generate [name] [destination]')
     .option('--color [boolean]', 'Turn on/off colors', 'true')
-    .option('--notree', 'Do not display generated file tree', false)
+    .option('--notree [boolean]', 'Do not display generated file tree', 'false')
     .option('--template <templateName>', 'Name of template to use')
     .description('Generates a workspace based on a template from the template repository')
     .action((name, destination, options) => { // deliberately not using withCompatibilityCheck()

--- a/src/commands/workspaces/generate.js
+++ b/src/commands/workspaces/generate.js
@@ -8,6 +8,7 @@ const inquirer = require('inquirer');
 const ghGot = require('gh-got');
 const { isText } = require('istextorbinary');
 const treeify = require('treeify');
+const { boolean } = require('boolean');
 
 const _ = {
   get: require('lodash/get'),
@@ -219,7 +220,7 @@ module.exports.WorkspaceGenerateCommand = class WorkspaceGenerateCommand {
             }
           }),
         );
-        if (!options || !options.notree) {
+        if (!options || !boolean(options.notree)) {
           printSuccess('Generated the following files:');
           console.log('');
           console.log(destinationPath);


### PR DESCRIPTION
As requested in FAB-4606, the --notree option should behave like the --color option, meaning that you can specify true or false as a value.