### PR TITLE
FAB-4815 - Dont allow "empty" registry name.

### DIFF
--- a/src/commands/workspaces/registry.js
+++ b/src/commands/workspaces/registry.js
@@ -110,7 +110,9 @@ module.exports.WorkspaceActivateRegistryCommand = class WorkspaceActivateRegistr
     this.program = program;
   }
 
-  async execute(name, options) {
+  async execute(regname, options) {
+    const name = regname || undefined;
+
     const profile = await loadProfile();
 
     const choices = _.map(_.filter(profile.registries, (r) => !name || (r.name === name)), (r) => (


### PR DESCRIPTION
Disallow using an empty registry name when activating a registry