### PR TITLE
FAB-4955 Make desc the default so newer (larger) starttime are at top

### DIFF
--- a/bin/cortex-tasks.js
+++ b/bin/cortex-tasks.js
@@ -53,7 +53,7 @@ program
     .option('--filter <filter>', 'A Mongo style filter to use.')
     .option('--limit <limit>', 'Limit number of records', DEFAULT_LIST_LIMIT_COUNT)
     .option('--skip <skip>', 'Skip number of records', DEFAULT_LIST_SKIP_COUNT)
-    .option('--sort <asc|desc|sort>', 'Sort asc|desc on startTime or Mongo style sort statement.', 'asc')
+    .option('--sort <asc|desc|sort>', 'Sort asc|desc on startTime or Mongo style sort statement.', 'desc')
     .action(withCompatibilityCheck(async (options) => {
         try {
             await new ListTasksCommand(program).execute(options);


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ x] Notified docs of any potential USER-facing changes
- [ x] Added short description of the change - with relevant motivation and context. 
- [ x] Branch has the ticket number in its name (along with a ticket summary)
- [ x] Commented the code, particularly in hard-to-understand areas
- [ x] Added tests that prove my fix is effective or that my feature works
- [ x] Ran `npm test` and it passes
- [x ] Changes generate no new warnings
- [x ] Changes are backward compatible with older clusters
