### PR TITLE
Pipeline stage to handle merge up to main

### DIFF
--- a/cortex-cli.gocd.yaml
+++ b/cortex-cli.gocd.yaml
@@ -31,6 +31,30 @@ pipelines:
                     git clone git@github.com:CognitiveScale/gocd-pipeline-scripts.git
                     ./gocd-pipeline-scripts/common/c12e-common.sh dev
                     echo ./gocd-pipeline-scripts/cortex5/docs/update-docs.sh cli
+      - publish:
+          clean_workspace: true
+          approval:
+            type: manual
+          jobs:
+            Promote:
+              elastic_profile_id: gocd-test-agent-dind
+              environment_variables:
+                PROMOTE_BRANCH: "main"
+              tasks:
+                - fetch:
+                    stage: build
+                    job: create
+                    source: devBranchRevision.json
+                    is_file: yes
+                - script: |
+                    set -eux
+                    
+                    COMMIT_SHA="$(cat devBranchRevision.json)"
+                    git fetch
+                    git checkout -b ${PROMOTE_BRANCH} origin/${PROMOTE_BRANCH}
+                    git merge ${COMMIT_SHA} \
+                    --ff-only
+                    git push origin ${PROMOTE_BRANCH}
   cortex-cli-master:
     group: fabric6-rc
     environment_variables:


### PR DESCRIPTION
add a new manually approved stage to develop pipeline to handle fast-forward merge up to main for a release

We can still use the PR's to review what's included in a release but now we should be able to rely on the pipeline to handle the merge for us (and also without taking the extra merge commit into main)