### PR TITLE
Forgot to include Typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "files": [
     "bin/*",
     "src/*",
+    "client/*",
     "README.md",
     "npm-shrinkwrap.json",
     "LICENSE"


### PR DESCRIPTION
The types for Typescript need to be included in the distribution, so the IDE extension can use the package.