### PR TITLE
revert minimum node version back to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=14.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I bumped this incorrectly while trying to figure out issues with the test image last week.. turns out we need to allow node 14 for certain customers