### PR TITLE
remove extra call to delete project graphql api

### DIFF
--- a/src/commands/projects.js
+++ b/src/commands/projects.js
@@ -118,7 +118,6 @@ module.exports.DeleteProjectCommand = class DeleteProjectCommand {
         debug('%s.executeDeleteProject(%s)', profile.name, projectName);
         try {
             const cli = new ApiServerClient(profile.url);
-            await cli.deleteProject(profile.token, projectName);
             const status = await cli.deleteProject(profile.token, projectName);
             if (status) {
                 printSuccess(`Project ${projectName} deleted`, options);


### PR DESCRIPTION
Had a test failure in `dci-integration` where the project delete call was failing, turns out we were double tapping the api so the first call succeeded (project was deleted) and then the second call would fail because the project was already deleted.