### PR TITLE
use options.json instead of body for printing debug output

### DIFF
--- a/src/client/apiutils.js
+++ b/src/client/apiutils.js
@@ -20,7 +20,7 @@ module.exports.got = got.extend({
                     debug(`request url: ${options.url}`);
                     debug(`request methods: ${options.method}`);
                     debug(`request headers: ${JSON.stringify(options.headers)}`);
-                    debug(`request body: ${options.body || '{}'}`);
+                    debug(`request json: ${JSON.stringify(options.json)}`);
                 }
             },
         ],


### PR DESCRIPTION
Was relying on the `--debug` output for figuring out the request/response structures for the TSOA migration.. I thought `options.body` had been working for some commands but when trying to test some of the service user API's I was getting `{}` returned.

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
- [ ] Changes are backward compatible with older clusters
