### PR TITLE
Override "-V" default version option set by commander

### DIFF
--- a/bin/cortex.js
+++ b/bin/cortex.js
@@ -5,7 +5,7 @@ import { readPackageJSON } from '../src/commands/utils.js';
 
 export function create() {
     const program = new Command();
-    program.version(readPackageJSON('../../package.json').version);
+    program.version(readPackageJSON('../../package.json').version, '-v, --version', 'Outputs the installed version of the Cortex CLI');
     program.name('cortex');
     program
         .description('Cortex CLI')


### PR DESCRIPTION
- Use the previous `-v` flag instead

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
- [ ] Changes are backward compatible with older clusters
