### PR TITLE
Add `--skip-connection-check` option when saving a Pipeline Repository

### DIFF
--- a/bin/cortex-pipelines-repos.js
+++ b/bin/cortex-pipelines-repos.js
@@ -82,8 +82,8 @@ export function create() {
     .option('--color [boolean]', 'Turn on/off colors for JSON output.', 'true')
     .option('--profile <profile>', 'The profile to use')
     .option('--project <project>', 'The project to use')
+    .option('--skip-connection-check', 'Skip connection check to Pipeline Repository prior to saving Pipeline Repository.')
     .option('-y, --yaml', 'Use YAML for Pipeline Repository definition format')
-    // TODO: should this have CLI args for <repo> & <branch>??
     .action(withCompatibilityCheck((pipelineRepoDefinition, options) => {
       try {
         return new SavePipelineRepoCommand(repos).execute(pipelineRepoDefinition, options);

--- a/src/client/pipelineRepositories.js
+++ b/src/client/pipelineRepositories.js
@@ -30,9 +30,12 @@ export default class PipelineRepos {
     }
   }
 
-  async savePipelineRepo(projectId, token, repoObj) {
+  async savePipelineRepo(projectId, token, repoObj, skipConnectionCheck) {
     checkProject(projectId);
-    const endpoint = `${this.endpoint(projectId)}`;
+    let endpoint = `${this.endpoint(projectId)}`;
+    if (skipConnectionCheck) {
+      endpoint = `${endpoint}?skipConnectionCheck=true`;
+    }
     debug('savePipelineRepo(%s) => %s', repoObj.name, endpoint);
     try {
       return await got.post(endpoint, {

--- a/src/commands/pipelineRepositories.js
+++ b/src/commands/pipelineRepositories.js
@@ -28,7 +28,7 @@ export const SavePipelineRepoCommand = class {
     debug('%s', repoObj);
     const repo = new Pipelines(profile.url);
     try {
-      const response = await repo.savePipelineRepo(options.project || profile.project, profile.token, repoObj);
+      const response = await repo.savePipelineRepo(options.project || profile.project, profile.token, repoObj, options.skipConnectionCheck);
       if (response.success) {
         return printSuccess('Pipeline Repository saved', options);
       }

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -117,7 +117,7 @@ describe('Pipelines', () => {
       nock.isDone();
     });
 
-    it('saves a pipeline repository  ', async () => {
+    it('saves a pipeline repository', async () => {
       const repo = {
         name: 'repo1',
         repo: exampleRepo,
@@ -135,6 +135,33 @@ describe('Pipelines', () => {
       // invoke the CLI
       nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
       await create().parseAsync(['node', 'repos', 'save', filename, '--project', PROJECT]);
+      const output = getPrintedLines().join('');
+      const errs = getErrorLines().join('');
+      // verify response
+      chai.expect(output).to.contain('Pipeline Repository saved');
+      // eslint-disable-next-line no-unused-expressions
+      chai.expect(errs).to.be.empty;
+      nock.isDone();
+    });
+
+    it('saves a pipeline repository and skips connection check', async () => {
+      const repo = {
+        name: 'repo1',
+        repo: exampleRepo,
+        branch: 'develop',
+      };
+      const response = {
+        success: true,
+        version: 1,
+        message: 'pipelineRepository repo1 saved.',
+      };
+      // save definition of 'repo' to temporary file
+      const dir = await mkdtemp(join(tmpdir(), 'tmp-'));
+      const filename = join(dir, 'repo1.json');
+      await writeFile(filename, JSON.stringify(repo));
+      // invoke the CLI
+      nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
+      await create().parseAsync(['node', 'repos', 'save', filename, '--project', PROJECT, '--skip-connection-check']);
       const output = getPrintedLines().join('');
       const errs = getErrorLines().join('');
       // verify response


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [X] Added short description of the change - with relevant motivation and context. 
- [X] Branch has the ticket number in its name (along with a ticket summary)
- [X] Commented the code, particularly in hard-to-understand areas
- [X] Added tests that prove my fix is effective or that my feature works
- [X] Ran `npm test` and it passes
- [X] Changes generate no new warnings
- [X] Changes are backward compatible with older clusters

