### PR TITLE
Fab 6167 skillname

### DIFF
--- a/src/client/pipelineRepositories.js
+++ b/src/client/pipelineRepositories.js
@@ -75,7 +75,7 @@ export default class PipelineRepos {
     const params = {};
     const endpoint = `${this.endpoint(projectId)}/${encodeURIComponent(pipelineRepoName)}/update`;
     if (skill) {
-      params.skill = skill;
+      params.skillName = skill;
     }
     debug('updateRepoPipelines(%s) => %s', pipelineRepoName, endpoint);
     try {

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -226,7 +226,7 @@ describe('Pipelines', () => {
       .post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories\/.*\/update/)
       .query({ skillName: 'my-skill' })
       .reply(200, response);
-    await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skillName', 'my-skill']);
+    await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skill', 'my-skill']);
     const output = getPrintedLines().join('');
     const errs = getErrorLines().join('');
     chai.expect(output).to.contain('pipeline1');

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -224,9 +224,9 @@ describe('Pipelines', () => {
 
     nock(serverUrl)
       .post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories\/.*\/update/)
-      .query({ skill: 'my-skill' })
+      .query({ skillName: 'my-skill' })
       .reply(200, response);
-    await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skill', 'my-skill']);
+    await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skillName', 'my-skill']);
     const output = getPrintedLines().join('');
     const errs = getErrorLines().join('');
     chai.expect(output).to.contain('pipeline1');


### PR DESCRIPTION
Catalog service is expecting skillName, not skill in query param

# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [ ] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [ ] Commented the code, particularly in hard-to-understand areas
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Ran `npm test` and it passes
- [ ] Changes generate no new warnings
- [ ] Changes are backward compatible with older clusters
