### PR TITLE
Support saving a Pipeline Repo using CLI flags without the definition file

### DIFF
--- a/bin/cortex-pipelines-repos.js
+++ b/bin/cortex-pipelines-repos.js
@@ -77,7 +77,7 @@ export function create() {
 
    // Save
   repos
-    .command('save <pipelineRepoDefinition>')
+    .command('save [pipelineRepoDefinition]')
     .description('Save a Pipeline Repository definition. Takes JSON file by default.')
     .option('--no-compat', 'Ignore API compatibility checks')
     .option('--color [boolean]', 'Turn on/off colors for JSON output.', 'true')

--- a/src/commands/pipelineRepositories.js
+++ b/src/commands/pipelineRepositories.js
@@ -22,7 +22,7 @@ export const SavePipelineRepoCommand = class {
     let repoObj = {};
     if (pipelineRepoDefinition && !fileExists(pipelineRepoDefinition)) {
       printError(`File does not exist at: ${pipelineRepoDefinition}`);
-    } else {
+    } else if (pipelineRepoDefinition) {
       const repoDefStr = fs.readFileSync(pipelineRepoDefinition);
       repoObj = parseObject(repoDefStr, options);
     }

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -117,7 +117,7 @@ describe('Pipelines', () => {
       nock.isDone();
     });
 
-    it('saves a pipeline repository  ', async () => {
+    it('saves a pipeline repository', async () => {
       const repo = {
         name: 'repo1',
         repo: exampleRepo,
@@ -135,6 +135,24 @@ describe('Pipelines', () => {
       // invoke the CLI
       nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
       await create().parseAsync(['node', 'repos', 'save', filename, '--project', PROJECT]);
+      const output = getPrintedLines().join('');
+      const errs = getErrorLines().join('');
+      // verify response
+      chai.expect(output).to.contain('Pipeline Repository saved');
+      // eslint-disable-next-line no-unused-expressions
+      chai.expect(errs).to.be.empty;
+      nock.isDone();
+    });
+
+    it('saves a pipeline repository using CLI flags', async () => {
+      const response = {
+        success: true,
+        version: 1,
+        message: 'pipelineRepository testpipeline saved.',
+      };
+      // invoke the CLI
+      nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
+      await create().parseAsync(['node', 'repos', 'save', '--name', 'testpipeline', '--branch', 'develop', '--repo', 'mc://test.key', '--project', PROJECT]);
       const output = getPrintedLines().join('');
       const errs = getErrorLines().join('');
       // verify response

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -3,6 +3,7 @@ import mockedEnv from 'mocked-env';
 import nock from 'nock';
 import _ from 'lodash';
 import sinon from 'sinon';
+import yaml from 'js-yaml';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -117,7 +118,7 @@ describe('Pipelines', () => {
       nock.isDone();
     });
 
-    it('saves a pipeline repository', async () => {
+    it('saves a pipeline repository (json)', async () => {
       const repo = {
         name: 'repo1',
         repo: exampleRepo,
@@ -135,6 +136,33 @@ describe('Pipelines', () => {
       // invoke the CLI
       nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
       await create().parseAsync(['node', 'repos', 'save', filename, '--project', PROJECT]);
+      const output = getPrintedLines().join('');
+      const errs = getErrorLines().join('');
+      // verify response
+      chai.expect(output).to.contain('Pipeline Repository saved');
+      // eslint-disable-next-line no-unused-expressions
+      chai.expect(errs).to.be.empty;
+      nock.isDone();
+    });
+
+    it('saves a pipeline repository (yaml)', async () => {
+      const repo = {
+        name: 'repo1',
+        repo: exampleRepo,
+        branch: 'develop',
+      };
+      const response = {
+        success: true,
+        version: 1,
+        message: 'pipelineRepository repo1 saved.',
+      };
+      // save definition of 'repo' to temporary file
+      const dir = await mkdtemp(join(tmpdir(), 'tmp-'));
+      const filename = join(dir, 'repo1.yaml');
+      await writeFile(filename, yaml.dump(repo));
+      // invoke the CLI
+      nock(serverUrl).post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories/).reply(200, response);
+      await create().parseAsync(['node', 'repos', 'save', '-y', filename, '--project', PROJECT]);
       const output = getPrintedLines().join('');
       const errs = getErrorLines().join('');
       // verify response


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [X] Added short description of the change - with relevant motivation and context. 
- [X] Branch has the ticket number in its name (along with a ticket summary)
- [X] Commented the code, particularly in hard-to-understand areas
- [X] Added tests that prove my fix is effective or that my feature works
- [X] Ran `npm test` and it passes
- [X] Changes generate no new warnings
- [X] Changes are backward compatible with older clusters

Found a small bug where the PipelineRepoDefinition (file) is still required even if you use the convenience CLI flags. Added a unit test to prove the fix works and the command supports JSON & YAML

Related Issue: https://cognitivescale.atlassian.net/browse/FAB-6172
