### PR TITLE
fixed TSOA error response - key without period (.)

### DIFF
--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -358,12 +358,17 @@ const transformTSOAValidation = (responseDetails) => {
             const transformedResp = [];
             for (let i = 0; i < keys.length; i += 1) {
                 const key = keys[i];
+                const { message } = _.get(responseDetails, key, {});
+
+                // If the key includes a single dot (.)
                 if (key.includes('.') && key.split('.').length === 2) {
-                    const { message } = _.get(responseDetails, key, {});
                     if (message) {
                         // Transform error object
                         transformedResp.push({ type: key.split('.')[1], message });
                     }
+                    // If key doesn't include a period dot (.)
+                } else if (!key.includes('.')) {
+                    transformedResp.push({ type: key, message });
                 }
             }
             if (transformedResp.length > 0) {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -146,6 +146,25 @@ describe('Test handleListFailure function', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(process.exit.calledWith(1)).to.be.true;
     });
+    const errResponseTsoaWithoutKey = {
+        status: 400,
+        details: {
+            type1: {
+                message: 'message1',
+                value: '-1',
+            },
+        },
+    };
+    it('should print tabular output if status is 400 with TSOA response without dot in the key', () => {
+        handleListFailure(errResponseTsoaWithoutKey, null, 'test-resource');
+        expect((getPrintedLines()[0])).to.equal('┌────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐\n'
+            + '│ Option Type        │ Message                                                                                                                │\n'
+            + '├────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤\n'
+            + '│ type1              │ message1                                                                                                               │\n'
+            + '└────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘');
+        // eslint-disable-next-line no-unused-expressions
+        expect(process.exit.calledWith(1)).to.be.true;
+    });
 });
 describe('Test handleDeleteFailure', () => {
     let printSpy;


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [x] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [x] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters

Changes:
* Handles error response from `cortex tasks lists` which doesn't include a period in the key.

```
{
        status: 400,
        details: {
            type1: {
                message: 'message1',
                value: '-1',
            },
        },
    }
```
