### PR TITLE
Add environment variable & CLI flag overrides for Timeout & Retry settings

### DIFF
--- a/bin/cortex.js
+++ b/bin/cortex.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import esMain from 'es-main';
-import { readPackageJSON } from '../src/commands/utils.js';
+import { readPackageJSON, printError } from '../src/commands/utils.js';
 import { loadProfileWithoutFailure } from '../src/config.js';
 import { getAllSubcommands, FeatureController } from '../src/features.js';
 
@@ -15,11 +15,19 @@ async function resolveAvailableSubcommands(profileName) {
         // testing
         supportedCommands = getAllSubcommands();
     } else {
-        if (profile === undefined || profile === null) {
-            // Check to only Load the users Profile & do a compatibility check
-            // once on startup
-            profile = await loadProfileWithoutFailure(profileName);
-        }
+      if (profile === undefined || profile === null) {
+          // Alert the user that CORTEX_TOKEN is set, this has a higher
+          // priority than other methods of retrieving the token. The Alert
+          // happens at startup, rather than downstream when getting the value
+          // from the env, as to only alert the user once (avoid duplicate
+          // messages in cases where the variable is loaded multiple times).
+          if (process.env.CORTEX_TOKEN) {
+              printError('Using token from "CORTEX_TOKEN" environment variable', {}, false);
+          }
+          // Check to only Load the users Profile & do a compatibility check
+          // once on startup
+          profile = await loadProfileWithoutFailure(profileName);
+      }
         if (profile) {
             // if the profile was found, then side-load the token & feature
             // flags to avoid future calls to the server

--- a/bin/cortex.js
+++ b/bin/cortex.js
@@ -57,6 +57,10 @@ export async function create(profileName) {
         .option('--debug', 'Enables enhanced log output for debugging', false)
         .on('option:debug', () => {
             process.env.DEBUG = '*';
+        })
+        .option('--no-timeout', 'Disables all network timeouts for slower connections (not recommended)')
+        .on('option:no-timeout', () => {
+            process.env.CORTEX_TIMEOUT_IGNORE = '*';
         });
     const supportedCommands = await resolveAvailableSubcommands(profileName);
     const _toObject = (nameAndArgs, description) => ({ nameAndArgs, description });

--- a/src/client/apiutils.js
+++ b/src/client/apiutils.js
@@ -16,8 +16,8 @@ const gotOpts = {
     followRedirect: false,
     // Put a reasonable timeout, see: https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md
     timeout: {
-        lookup: 100,
-        connect: 50,
+        lookup: 75, // greater than 100 not recommended
+        connect: 100,
         secureConnect: 100,
         socket: 1000,
         // send: 10000, // Not "SAFE" with large uploads

--- a/src/client/apiutils.js
+++ b/src/client/apiutils.js
@@ -155,17 +155,22 @@ export function getTimeoutUnit() {
 function getEnvOptions() {
     const retry = {};
     const timeout = {};
-    const { timeout: timeoutValues, retry: retryValues } = getGotEnvOverrides();
-    timeoutValues.forEach((t) => {
-        if (!t.skipAssignment) {
-            timeout[t.key] = t.parsedValue ?? t.defaultValue; // could use 'userDefined', but ?? is shorter
-        }
-    });
-    retryValues.forEach((v) => {
-        if (!v.skipAssignment) {
-            retry[v.key] = v.parsedValue ?? v.defaultValue; // could use 'userDefined', but ?? is shorter
-        }
-    });
+    if (process.env.CORTEX_TIMEOUT_IGNORE) {
+        debug('Ignoring all timeout configuration from env variables');
+    } else {
+        debug('Loading timeout configuration from env variables');
+        const { timeout: timeoutValues, retry: retryValues } = getGotEnvOverrides();
+        timeoutValues.forEach((t) => {
+            if (!t.skipAssignment) {
+                timeout[t.key] = t.parsedValue ?? t.defaultValue; // could use 'userDefined', but ?? is shorter
+            }
+        });
+        retryValues.forEach((v) => {
+            if (!v.skipAssignment) {
+                retry[v.key] = v.parsedValue ?? v.defaultValue; // could use 'userDefined', but ?? is shorter
+            }
+        });
+    }
     return { ...gotOpts, timeout, retry };
 }
 

--- a/src/client/apiutils.js
+++ b/src/client/apiutils.js
@@ -14,7 +14,7 @@ function getUserAgent() {
 
 const gotOpts = {
     followRedirect: false,
-    // Put a reasonable timeout
+    // Put a reasonable timeout, see: https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md
     timeout: {
         lookup: 100,
         connect: 50,
@@ -57,6 +57,77 @@ const gotOpts = {
         ],
     },
 };
-const gotExt = got.extend(gotOpts);
+
+export function getTimeoutValues() {
+    return [
+        {
+            envVar: 'CORTEX_TIMEOUT_LOOKUP',
+            envValue: process.env.CORTEX_TIMEOUT_LOOKUP,
+            defaultValue: gotOpts.timeout.lookup,
+            key: 'lookup',
+        },
+        {
+            envVar: 'CORTEX_TIMEOUT_CONNECT',
+            envValue: process.env.CORTEX_TIMEOUT_CONNECT,
+            defaultValue: gotOpts.timeout.connect,
+            key: 'connect',
+        },
+        {
+            envVar: 'CORTEX_TIMEOUT_SECURE_CONNECT',
+            envValue: process.env.CORTEX_TIMEOUT_SECURE_CONNECT,
+            defaultValue: gotOpts.timeout.secureConnect,
+            key: 'secureConnect',
+        },
+        {
+            envVar: 'CORTEX_TIMEOUT_SOCKET',
+            envValue: process.env.CORTEX_TIMEOUT_SOCKET,
+            defaultValue: gotOpts.timeout.socket,
+            key: 'socket',
+        },
+        // {
+        //     envVar: 'CORTEX_TIMEOUT_SEND',
+        //     envValue: process.env.CORTEX_TIMEOUT_SEND,
+        //     defaultValue: gotOpts.timeout.send,
+        //     key: 'send',
+        // },
+        {
+            envVar: 'CORTEX_TIMEOUT_RESPONSE',
+            envValue: process.env.CORTEX_TIMEOUT_RESPONSE,
+            defaultValue: gotOpts.timeout.response,
+            key: 'response',
+        },
+    ];
+}
+
+export function getTimeoutUnit() {
+    return 'ms';
+}
+
+function getEnvOptions() {
+    function resolveTimeout(v) {
+        // if its nullish -> keep the default
+        // if its a positive number -> parse as an int, then apply to k
+        // if its falsey or non-positive number -> use no timeout
+        if (v == null) {
+            return null; // use default
+        }
+        const value = parseInt(v, 10);
+        if (value > 0) {
+            return value; // user defined int
+        }
+        return false; // use no timeout
+    }
+    const timeout = {};
+    const timeoutValues = getTimeoutValues();
+    timeoutValues.forEach((t) => {
+        const parsed = resolveTimeout(t.envValue);
+        if (parsed !== false) {
+            timeout[t.key] = parsed ?? t.defaultValue;
+        }
+    });
+    return { ...gotOpts, timeout };
+}
+
+const gotExt = got.extend(getEnvOptions());
 export const defaultHeaders = (token, otherHeaders = {}) => ({ Authorization: `Bearer ${token}`, ...otherHeaders });
 export { gotExt as got };

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -160,8 +160,7 @@ export const PrintEnvVars = class {
         try {
             // Token & URI are not picked from env variables, likely because
             // this command is meant to help the user configure their env based
-            // on their profile.  Picking up env variables would be
-            // inconsistent.
+            // on their profile. Picking up env variables would be inconsistent!
             const vars = [];
             const defaults = [];
             const profile = await loadProfile(options.profile, false);
@@ -176,7 +175,7 @@ export const PrintEnvVars = class {
             vars.push(`export CORTEX_URL=${profile.url}`);
             vars.push(`export CORTEX_PROJECT=${options.project || profile.project}`);
 
-            // Print timeout options, including time unit
+            // Include timeout options with units & default
             const { timeout, retry } = getGotEnvOverrides();
             const unit = getTimeoutUnit();
             const len = 60; // fixed length to apply consistent spacing
@@ -196,7 +195,7 @@ export const PrintEnvVars = class {
                 }
             });
 
-            // Print retry options
+            // Include retry options with defaults
             retry.forEach((v) => {
                 if (v.userDefined) {
                     // Print the exact value set by the user
@@ -210,9 +209,24 @@ export const PrintEnvVars = class {
                     defaults.push(`${exportPart}${spacing}${defaultPart}`);
                 }
             });
-            vars.push('\n# The default value is used for the following environment variables. Non-negative\n'
-                + '# integer values will be applied to timeouts, while all other values will disable the timeout.\n#',
-                ...defaults);
+
+            // Include reference text as bash comments (slightly verbose)
+            if (defaults.length > 0) {
+                vars.push('\n# The default value is used for the following environment variables.',
+                    '# Non-negative integers values will be applied to timeouts, while all other',
+                    '# values will disable the timeout. For additional information on the timeout',
+                    '# meanings, refer to the corresponding timeout values at:',
+                    '# https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md',
+                    '#',
+                    ...defaults);
+            } else {
+                vars.push('\n# Non-negative integer values will be applied to timeouts, while all other',
+                    '# values will disable the timeout. For additional information on the timeout',
+                    '# meanings, refer to the corresponding timeout values at:',
+                    '# https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md',
+                    '#',
+                    ...defaults);
+            }
             return printSuccess(vars.join('\n'), { color: 'off' });
         } catch (err) {
             return printError(err.message, {}, true);

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -210,7 +210,9 @@ export const PrintEnvVars = class {
                     defaults.push(`${exportPart}${spacing}${defaultPart}`);
                 }
             });
-            vars.push('\n# The default value is used for the following environment variables:\n#', ...defaults);
+            vars.push('\n# The default value is used for the following environment variables. Non-negative\n'
+                + '# integer values will be applied to timeouts, while all other values will disable the timeout.\n#',
+                ...defaults);
             return printSuccess(vars.join('\n'), { color: 'off' });
         } catch (err) {
             return printError(err.message, {}, true);

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -184,12 +184,12 @@ export const PrintEnvVars = class {
                 if (t.envValue == null) {
                     // using default
                     const defaultPart = `(default: ${t.defaultValue}, unit: ${unit})`;
-                    const exportPart = `export ${t.envVar}=`;
+                    const exportPart = `#export ${t.envVar}=`;
                     const spacing = ' '.repeat(len - exportPart.length);
                     vars.push(`${exportPart}${spacing}${defaultPart}`);
                 } else {
                     // user set value
-                    const unitPart = `(unit: ${unit})`;
+                    const unitPart =  `# (unit: ${unit})`;
                     const exportPart = `export ${t.envVar}=${t.envValue}`;
                     const spacing = ' '.repeat(len - exportPart.length);
                     vars.push(`${exportPart}${spacing}${unitPart}`);

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -189,7 +189,7 @@ export const PrintEnvVars = class {
                     vars.push(`${exportPart}${spacing}${defaultPart}`);
                 } else {
                     // user set value
-                    const unitPart =  `# (unit: ${unit})`;
+                    const unitPart = `# (unit: ${unit})`;
                     const exportPart = `export ${t.envVar}=${t.envValue}`;
                     const spacing = ' '.repeat(len - exportPart.length);
                     vars.push(`${exportPart}${spacing}${unitPart}`);

--- a/src/commands/configure.js
+++ b/src/commands/configure.js
@@ -163,6 +163,7 @@ export const PrintEnvVars = class {
             // on their profile.  Picking up env variables would be
             // inconsistent.
             const vars = [];
+            const defaults = [];
             const profile = await loadProfile(options.profile, false);
             const ttl = options.ttl || '1d';
             if (!durationRegex.test(ttl)) {
@@ -191,7 +192,7 @@ export const PrintEnvVars = class {
                     const defaultPart = `(default: ${t.defaultValue}, unit: ${unit})`;
                     const exportPart = `#export ${t.envVar}=`;
                     const spacing = ' '.repeat(len - exportPart.length);
-                    vars.push(`${exportPart}${spacing}${defaultPart}`);
+                    defaults.push(`${exportPart}${spacing}${defaultPart}`);
                 }
             });
 
@@ -206,9 +207,10 @@ export const PrintEnvVars = class {
                     const defaultPart = `(default: ${v.defaultValue})`;
                     const exportPart = `#export ${v.envVar}=`;
                     const spacing = ' '.repeat(len - exportPart.length);
-                    vars.push(`${exportPart}${spacing}${defaultPart}`);
+                    defaults.push(`${exportPart}${spacing}${defaultPart}`);
                 }
             });
+            vars.push('\n# The default value is used for the following environment variables:\n#', ...defaults);
             return printSuccess(vars.join('\n'), { color: 'off' });
         } catch (err) {
             return printError(err.message, {}, true);

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -140,7 +140,9 @@ export const constructError = (error) => {
         details = error.message;
     } else if (error.name === 'TimeoutError' || error.code === 'ETIMEDOUT') {
         errorText = error.message;
-        details = 'Try increasing the network timeout values via environment variables.\nRun "cortex configure env" to view your current network timeout settings.';
+        details = '\nTry running the command again with \'--no-timeout\' or increase\n'
+            + 'the network timeout values via environment variables. Run\n'
+            + '"cortex configure env" to view your current network timeout settings.';
     }
     // if JSON was returned, look for either a message or error in it
     try {

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -142,7 +142,8 @@ export const constructError = (error) => {
         errorText = error.message;
         details = '\nTry running the command again with \'--no-timeout\' or increase\n'
             + 'the network timeout values via environment variables. Run\n'
-            + '"cortex configure env" to view your current network timeout settings.';
+            + '"cortex configure env" to view the environment variables\n'
+            + 'controlling the network timeout settings.';
     }
     // if JSON was returned, look for either a message or error in it
     try {

--- a/src/commands/utils.js
+++ b/src/commands/utils.js
@@ -138,6 +138,9 @@ export const constructError = (error) => {
     } else if (error.name === 'ParseError' || error.code === 'ERR_BODY_PARSE_FAILURE') {
         errorText = 'Unable to parse response from server. Try running again with "--debug" for more details.';
         details = error.message;
+    } else if (error.name === 'TimeoutError' || error.code === 'ETIMEDOUT') {
+        errorText = error.message;
+        details = 'Try increasing the network timeout values via environment variables.\nRun "cortex configure env" to view your current network timeout settings.';
     }
     // if JSON was returned, look for either a message or error in it
     try {
@@ -569,8 +572,11 @@ export function handleError(error, options, prefix = 'Error') {
     const normedError = constructError(error);
     printError(`${prefix}: ${normedError.status}, ${normedError.message}`, undefined, false);
     if (normedError.details !== undefined && normedError.details !== null) {
-        // TSOA API validation error case
-        if (!Array.isArray(normedError.details)) {
+        if (typeof normedError.details === 'string' || normedError.details instanceof String) {
+            // Print details if its a string, and exit
+            printError(normedError.details);
+        } else if (!Array.isArray(normedError.details)) {
+            // TSOA API validation error case
             const transformedResponse = transformTSOAValidation(normedError.details);
             if (transformedResponse !== null) {
                 normedError.details = transformedResponse;

--- a/src/config.js
+++ b/src/config.js
@@ -126,7 +126,6 @@ async function loadDynamicProfileProps(profileType, useenv) {
         let jwtFromEnv;
         if (process.env.CORTEX_TOKEN) {
             jwtFromEnv = process.env.CORTEX_TOKEN;
-            printError('Using token from "CORTEX_TOKEN" environment variable', {}, false);
         }
         profileType.url = getCortexUrlFromEnv() || profileType.url;
         profileType.token = jwtFromEnv || profileType.token;

--- a/test/configure.js
+++ b/test/configure.js
@@ -133,7 +133,7 @@ describe('configure', () => {
 
     describe('Configure Env', () => {
         const project = 'testproject';
-        const totalVars = 4 + 5 + 1; // default + timeouts + retries
+        const totalVars = 4 + 5 + 1 + 3; // default + timeouts + retries + extra
         // eslint-disable-next-line max-len
         const expectedToken = 'eyJhbGciOiJFZERTQSIsImtpZCI6Ilg0dTJIdjRWeEw3N2JFOE45ZFQ0bHRWQm9Kc1NMVEg0YlkxYTVXTDZ3TlkifQ.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJhdWQiOiJjb3J0ZXgiLCJpc3MiOiJjb2duaXRpdmVzY2FsZS5jb20iLCJpYXQiOjEyOTQ3NjU4NzEsImV4cCI6MTI5NDg1MjI3MX0.JyU-9ie7W_YlGxj76A2VQa2H9Ex_lE-KttQxV1wRLOCki48QvabDMmKsb3fDRMK0zoW_ZSpN7KlNU6S5a7lwBA';
 

--- a/test/configure.js
+++ b/test/configure.js
@@ -144,8 +144,8 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
             // default timeouts
-            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
-            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 50, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 75, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 100, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SECURE_CONNECT=                      (default: 100, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
@@ -210,7 +210,7 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts
-            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 75, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
             // prints user defined variables

--- a/test/configure.js
+++ b/test/configure.js
@@ -132,9 +132,7 @@ describe('configure', () => {
 
     describe('Configure Env', () => {
         const project = 'testproject';
-        const numDefaultVars = 4;
-        const numTimeoutVars = 5;
-        const totalVars = numDefaultVars + numTimeoutVars;
+        const totalVars = 4 + 5 + 1; // default + timeouts + retries
         const expectedToken = 'eyJhbGciOiJFZERTQSIsImtpZCI6Ilg0dTJIdjRWeEw3N2JFOE45ZFQ0bHRWQm9Kc1NMVEg0YlkxYTVXTDZ3TlkifQ.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJhdWQiOiJjb3J0ZXgiLCJpc3MiOiJjb2duaXRpdmVzY2FsZS5jb20iLCJpYXQiOjEyOTQ3NjU4NzEsImV4cCI6MTI5NDg1MjI3MX0.JyU-9ie7W_YlGxj76A2VQa2H9Ex_lE-KttQxV1wRLOCki48QvabDMmKsb3fDRMK0zoW_ZSpN7KlNU6S5a7lwBA';
 
         it('prints cortex env variables', async () => {
@@ -151,6 +149,7 @@ describe('configure', () => {
             expect(output).to.include('#export CORTEX_TIMEOUT_SECURE_CONNECT=                      (default: 100, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
+            expect(output).to.include('#export CORTEX_API_RETRY=                                   (default: 3)');
         });
 
         it('configure env does NOT pick up CORTEX_TOKEN & CORTEX_URI environment variables', async () => {
@@ -168,14 +167,16 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts
-            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
-            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 50, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 75, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 100, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SECURE_CONNECT=                      (default: 100, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
+            expect(output).to.include('#export CORTEX_API_RETRY=                                   (default: 3)');
         });
 
         it('prints user defined timeout environment variables', async () => {
+            process.env.CORTEX_API_RETRY = 0;
             process.env.CORTEX_TIMEOUT_LOOKUP = 100;
             process.env.CORTEX_TIMEOUT_CONNECT = 200;
             process.env.CORTEX_TIMEOUT_SECURE_CONNECT = 'false';
@@ -194,9 +195,11 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=false                  # (unit: ms)');
             expect(output).to.include('export CORTEX_TIMEOUT_SOCKET=1000                           # (unit: ms)');
             expect(output).to.include('export CORTEX_TIMEOUT_RESPONSE=2000                         # (unit: ms)');
+            expect(output).to.include('export CORTEX_API_RETRY=0');
         });
 
         it('prints user defined timeout environment variables along with defaults', async () => {
+            process.env.CORTEX_API_RETRY = 0;
             process.env.CORTEX_TIMEOUT_CONNECT = 200;
             process.env.CORTEX_TIMEOUT_SECURE_CONNECT = 'false';
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
@@ -213,6 +216,7 @@ describe('configure', () => {
             // prints user defined variables
             expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=200                           # (unit: ms)');
             expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=false                  # (unit: ms)');
+            expect(output).to.include('export CORTEX_API_RETRY=0');
         });
     });
 });

--- a/test/configure.js
+++ b/test/configure.js
@@ -138,7 +138,9 @@ describe('configure', () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
+            // token is dynamic (not checking exact value)
+            // eslint-disable-next-line no-unused-expressions
+            expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
@@ -161,10 +163,12 @@ describe('configure', () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
+            // token is dynamic (not checking exact value)
+            // eslint-disable-next-line no-unused-expressions
+            expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
+            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
             // default timeouts
             expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 75, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 100, unit: ms)');
@@ -184,10 +188,12 @@ describe('configure', () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
+            // token is dynamic (not checking exact value)
+            // eslint-disable-next-line no-unused-expressions
+            expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
+            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
             // prints user defined variables
             expect(output).to.include('export CORTEX_TIMEOUT_LOOKUP=100                            # (unit: ms)');
             expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=200                           # (unit: ms)');
@@ -204,10 +210,12 @@ describe('configure', () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
+            // token is dynamic (not checking exact value)
+            // eslint-disable-next-line no-unused-expressions
+            expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
+            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
             // default timeouts
             expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 75, unit: ms)');
             expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');

--- a/test/configure.js
+++ b/test/configure.js
@@ -134,14 +134,11 @@ describe('configure', () => {
     describe('Configure Env', () => {
         const project = 'testproject';
         const totalVars = 4 + 5 + 1 + 3; // default + timeouts + retries + extra
-        // eslint-disable-next-line max-len
-        const expectedToken = 'eyJhbGciOiJFZERTQSIsImtpZCI6Ilg0dTJIdjRWeEw3N2JFOE45ZFQ0bHRWQm9Kc1NMVEg0YlkxYTVXTDZ3TlkifQ.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJhdWQiOiJjb3J0ZXgiLCJpc3MiOiJjb2duaXRpdmVzY2FsZS5jb20iLCJpYXQiOjEyOTQ3NjU4NzEsImV4cCI6MTI5NDg1MjI3MX0.JyU-9ie7W_YlGxj76A2VQa2H9Ex_lE-KttQxV1wRLOCki48QvabDMmKsb3fDRMK0zoW_ZSpN7KlNU6S5a7lwBA';
-
         it('prints cortex env variables', async () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include(`export CORTEX_TOKEN=${expectedToken}`);
+            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
@@ -165,7 +162,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=${expectedToken}`);
+            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts
@@ -188,7 +185,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=${expectedToken}`);
+            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // prints user defined variables
@@ -208,7 +205,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=${expectedToken}`);
+            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts

--- a/test/configure.js
+++ b/test/configure.js
@@ -138,7 +138,7 @@ describe('configure', () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
-            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
+            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
@@ -162,7 +162,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
+            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts
@@ -185,7 +185,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
+            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // prints user defined variables
@@ -205,7 +205,7 @@ describe('configure', () => {
             const output = getPrintedLines()[0].split('\n');
             expect(output).to.length(totalVars);
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
-            expect(output).to.include(`export CORTEX_TOKEN=`); // token is dynamic (not checking exact value)
+            expect(output).to.include('export CORTEX_TOKEN='); // token is dynamic (not checking exact value)
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts

--- a/test/configure.js
+++ b/test/configure.js
@@ -133,7 +133,7 @@ describe('configure', () => {
 
     describe('Configure Env', () => {
         const project = 'testproject';
-        const totalVars = 4 + 5 + 1 + 3; // default + timeouts + retries + extra
+        const totalVars = 4 + 5 + 1 + 4; // # default vars + # timeouts vars + # retries var + # lines of extra text
         it('prints cortex env variables', async () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');

--- a/test/configure.js
+++ b/test/configure.js
@@ -134,6 +134,7 @@ describe('configure', () => {
     describe('Configure Env', () => {
         const project = 'testproject';
         const totalVars = 4 + 5 + 1; // default + timeouts + retries
+        // eslint-disable-next-line max-len
         const expectedToken = 'eyJhbGciOiJFZERTQSIsImtpZCI6Ilg0dTJIdjRWeEw3N2JFOE45ZFQ0bHRWQm9Kc1NMVEg0YlkxYTVXTDZ3TlkifQ.eyJzdWIiOiJ0ZXN0X3VzZXIiLCJhdWQiOiJjb3J0ZXgiLCJpc3MiOiJjb2duaXRpdmVzY2FsZS5jb20iLCJpYXQiOjEyOTQ3NjU4NzEsImV4cCI6MTI5NDg1MjI3MX0.JyU-9ie7W_YlGxj76A2VQa2H9Ex_lE-KttQxV1wRLOCki48QvabDMmKsb3fDRMK0zoW_ZSpN7KlNU6S5a7lwBA';
 
         it('prints cortex env variables', async () => {

--- a/test/configure.js
+++ b/test/configure.js
@@ -133,11 +133,11 @@ describe('configure', () => {
 
     describe('Configure Env', () => {
         const project = 'testproject';
-        const totalVars = 4 + 5 + 1 + 4; // # default vars + # timeouts vars + # retries var + # lines of extra text
+        const totalVars = 4 + 5 + 1; // # default vars + # timeouts vars + # retries var
         it('prints cortex env variables', async () => {
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
-            expect(output).to.length(totalVars);
+            expect(output?.length).to.be.above(totalVars); // above because of additional text
             // token is dynamic (not checking exact value)
             // eslint-disable-next-line no-unused-expressions
             expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
@@ -162,7 +162,7 @@ describe('configure', () => {
             process.env.CORTEX_URI = 'http://localhost:5000';
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
-            expect(output).to.length(totalVars);
+            expect(output?.length).to.be.above(totalVars); // above because of additional text
             // token is dynamic (not checking exact value)
             // eslint-disable-next-line no-unused-expressions
             expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
@@ -187,7 +187,7 @@ describe('configure', () => {
             process.env.CORTEX_TIMEOUT_RESPONSE = 2000;
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
-            expect(output).to.length(totalVars);
+            expect(output?.length).to.be.above(totalVars); // above because of additional text
             // token is dynamic (not checking exact value)
             // eslint-disable-next-line no-unused-expressions
             expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;
@@ -209,7 +209,7 @@ describe('configure', () => {
             process.env.CORTEX_TIMEOUT_SECURE_CONNECT = 'false';
             await create().parseAsync(['node', 'configure', 'env', '--project', project]);
             const output = getPrintedLines()[0].split('\n');
-            expect(output).to.length(totalVars);
+            expect(output?.length).to.be.above(totalVars); // above because of additional text
             // token is dynamic (not checking exact value)
             // eslint-disable-next-line no-unused-expressions
             expect(output.some((v) => v.includes('export CORTEX_TOKEN='))).to.be.true;

--- a/test/configure.js
+++ b/test/configure.js
@@ -53,6 +53,7 @@ describe('configure', () => {
         delete process.env.CORTEX_TIMEOUT_SECURE_CONNECT;
         delete process.env.CORTEX_TIMEOUT_SOCKET;
         delete process.env.CORTEX_TIMEOUT_RESPONSE;
+        delete process.env.CORTEX_API_RETRY;
     });
     afterEach(() => {
         sandbox.restore();

--- a/test/configure.js
+++ b/test/configure.js
@@ -146,11 +146,11 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             expect(output).to.include(`export CORTEX_PROJECT=${project}`);
             // default timeouts
-            expect(output).to.include('export CORTEX_TIMEOUT_LOOKUP=                               (default: 100, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=                              (default: 50, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=                       (default: 100, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SOCKET=                               (default: 1000, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_RESPONSE=                             (default: 2000, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 50, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_SECURE_CONNECT=                      (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
         });
 
         it('configure env does NOT pick up CORTEX_TOKEN & CORTEX_URI environment variables', async () => {
@@ -168,14 +168,14 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // default timeouts
-            expect(output).to.include('export CORTEX_TIMEOUT_LOOKUP=                               (default: 100, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=                              (default: 50, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=                       (default: 100, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SOCKET=                               (default: 1000, unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_RESPONSE=                             (default: 2000, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_CONNECT=                             (default: 50, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_SECURE_CONNECT=                      (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
         });
 
-        it('configure env does pick up timeout environment variables', async () => {
+        it('prints user defined timeout environment variables', async () => {
             process.env.CORTEX_TIMEOUT_LOOKUP = 100;
             process.env.CORTEX_TIMEOUT_CONNECT = 200;
             process.env.CORTEX_TIMEOUT_SECURE_CONNECT = 'false';
@@ -189,11 +189,30 @@ describe('configure', () => {
             expect(output).to.include('export CORTEX_URI=http://localhost:8000');
             expect(output).to.include('export CORTEX_URL=http://localhost:8000');
             // prints user defined variables
-            expect(output).to.include('export CORTEX_TIMEOUT_LOOKUP=100                            (unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=200                           (unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=false                  (unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_SOCKET=1000                           (unit: ms)');
-            expect(output).to.include('export CORTEX_TIMEOUT_RESPONSE=2000                         (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_LOOKUP=100                            # (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=200                           # (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=false                  # (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_SOCKET=1000                           # (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_RESPONSE=2000                         # (unit: ms)');
+        });
+
+        it('prints user defined timeout environment variables along with defaults', async () => {
+            process.env.CORTEX_TIMEOUT_CONNECT = 200;
+            process.env.CORTEX_TIMEOUT_SECURE_CONNECT = 'false';
+            await create().parseAsync(['node', 'configure', 'env', '--project', project]);
+            const output = getPrintedLines()[0].split('\n');
+            expect(output).to.length(totalVars);
+            expect(output).to.include(`export CORTEX_PROJECT=${project}`);
+            expect(output).to.include(`export CORTEX_TOKEN=${expectedToken}`);
+            expect(output).to.include('export CORTEX_URI=http://localhost:8000');
+            expect(output).to.include('export CORTEX_URL=http://localhost:8000');
+            // default timeouts
+            expect(output).to.include('#export CORTEX_TIMEOUT_LOOKUP=                              (default: 100, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_SOCKET=                              (default: 1000, unit: ms)');
+            expect(output).to.include('#export CORTEX_TIMEOUT_RESPONSE=                            (default: 2000, unit: ms)');
+            // prints user defined variables
+            expect(output).to.include('export CORTEX_TIMEOUT_CONNECT=200                           # (unit: ms)');
+            expect(output).to.include('export CORTEX_TIMEOUT_SECURE_CONNECT=false                  # (unit: ms)');
         });
     });
 });


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary) <-- woops
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters

Changes:
* Adds environment variable overrides for `got`'s Timeout & Retry values.
* Exposes above in the `cortex configure env` command
* Adds `--no-timeout`  flag that disables timeouts
* Fixes minor bug where `Using CORTEX_TOKEN from ...` message was printed multiple times
* Minor error handling update for timeouts - prints the information on how to resolve the error

Related Issue: https://cognitivescale.atlassian.net/browse/FAB-6392
