### PR TITLE
FAB-6283: Add --force-recreate flag to pipeline-update command to help with errors from timeouts

### DIFF
--- a/bin/cortex-pipelines-repos.js
+++ b/bin/cortex-pipelines-repos.js
@@ -108,6 +108,7 @@ export function create() {
     .option('--project <project>', 'The project to use')
     .option('--json [searchPath]', QUERY_JSON_HELP_TEXT)
     .option('--skill <skillName>', 'Name of the underlying Skill in the same Project to use for running the Pipeline')
+    .option('--force-recreate', 'Whether to force Pipelines to be recreated even if the Pipeline\'s state (git SHA) has not has not changed.')
     .action(withCompatibilityCheck((pipelineRepoName, options) => {
       try {
         checkForEmptyArgs({ pipelineRepoName });

--- a/src/client/pipelineRepositories.js
+++ b/src/client/pipelineRepositories.js
@@ -70,12 +70,15 @@ export default class PipelineRepos {
     }
   }
 
-  async updateRepoPipelines(projectId, token, pipelineRepoName, skill) {
+  async updateRepoPipelines(projectId, token, pipelineRepoName, skill, forceRecreate) {
     checkProject(projectId);
     const params = {};
     const endpoint = `${this.endpoint(projectId)}/${encodeURIComponent(pipelineRepoName)}/update`;
     if (skill) {
       params.skillName = skill;
+    }
+    if (forceRecreate) {
+      params.forceRecreate = true;
     }
     debug('updateRepoPipelines(%s) => %s', pipelineRepoName, endpoint);
     try {

--- a/src/commands/pipelineRepositories.js
+++ b/src/commands/pipelineRepositories.js
@@ -131,7 +131,7 @@ export const UpdateRepoPipelinesCommand = class {
     debug('%s.executeUpdateRepoPipelines(%s)', profile.name, pipelineRepoName);
     const repos = new Pipelines(profile.url);
     try {
-      const response = await repos.updateRepoPipelines(options.project || profile.project, profile.token, pipelineRepoName, options.skill);
+      const response = await repos.updateRepoPipelines(options.project || profile.project, profile.token, pipelineRepoName, options.skill, options.forceRecreate);
       // Check for 'updateReport' property
       if (response.updateReport) {
         const { message, updateReport, success } = response;

--- a/test/pipelineRepositories.js
+++ b/test/pipelineRepositories.js
@@ -280,7 +280,7 @@ describe('Pipelines', () => {
         nock.isDone();
       });
 
-      it('should update-pipelines with custom Skill', async () => {
+      it('should update-pipelines with a custom skill and forceRecreate query params', async () => {
         const response = {
           success: true,
           code: 200,
@@ -299,9 +299,9 @@ describe('Pipelines', () => {
 
         nock(serverUrl)
           .post(/\/fabric\/v4\/projects\/.*\/pipeline-repositories\/.*\/update/)
-          .query({ skillName: 'my-skill' })
+          .query({ skillName: 'my-skill', forceRecreate: true })
           .reply(200, response);
-        await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skill', 'my-skill']);
+        await create().parseAsync(['node', 'repos', 'update-pipelines', 'repo1', '--project', PROJECT, '--skill', 'my-skill', '--force-recreate']);
         const output = getPrintedLines().join('');
         const errs = getErrorLines().join('');
         chai.expect(output).to.equal(


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [x] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters

Related Issue: https://cognitivescale.atlassian.net/browse/FAB-6283 <-- not directly related, but encountered this inconvenience while working on this issue.