### PR TITLE
Pipeline usability updates

### DIFF
--- a/bin/cortex-pipelines.js
+++ b/bin/cortex-pipelines.js
@@ -100,7 +100,6 @@ export function create() {
   .option('--profile <profile>', 'The profile to use')
   .option('--project <project>', 'The project to use')
   .option('--json [searchPath]', QUERY_JSON_HELP_TEXT)
-  .option('--report', 'Whether to print out a summary report of the Pipeline run. Incompatible with `--json`')
   .action(withCompatibilityCheck((runId, options) => {
     try {
       checkForEmptyArgs({ runId });

--- a/bin/cortex-pipelines.js
+++ b/bin/cortex-pipelines.js
@@ -100,6 +100,7 @@ export function create() {
   .option('--profile <profile>', 'The profile to use')
   .option('--project <project>', 'The project to use')
   .option('--json [searchPath]', QUERY_JSON_HELP_TEXT)
+  .option('--report', 'Whether to print out a summary report of the Pipeline run. Incompatible with `--json`')
   .action(withCompatibilityCheck((runId, options) => {
     try {
       checkForEmptyArgs({ runId });

--- a/bin/cortex-pipelines.js
+++ b/bin/cortex-pipelines.js
@@ -76,6 +76,7 @@ export function create() {
   .option('--color [boolean]', 'Turn on/off colors for JSON output.', 'true')
   .option('--profile <profile>', 'The profile to use')
   .option('--project <project>', 'The project to use')
+  .option('--json [searchPath]', QUERY_JSON_HELP_TEXT)
   .option('--params <params>', 'JSON params to send to the action')
   .option('--params-file <paramsFile>', 'A file containing either JSON or YAML formatted params')
   .option('--commit <commit>', 'Git SHA for pipeline repository')

--- a/bin/cortex-pipelines.js
+++ b/bin/cortex-pipelines.js
@@ -36,6 +36,7 @@ export function create() {
     .option('--project <project>', 'The project to use')
     .option('--json [searchQuery]', LIST_JSON_HELP_TEXT)
     .option('--filter <filter>', 'A Mongo style filter to use.')
+    .option('--repo <pipelineRepo>', 'Convenience flag for filtering by Pipeline Repository. Has a lower priority than --filter')
     .option('--limit <limit>', 'Limit number of records', DEFAULT_LIST_LIMIT_COUNT)
     .option('--skip <skip>', 'Skip number of records', DEFAULT_LIST_SKIP_COUNT)
     .option('--sort <sort>', 'A Mongo style sort statement to use in the query.', GET_DEFAULT_SORT_CLI_OPTION(DEFAULT_LIST_SORT_PARAMS.updatedAt))

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -175,7 +175,10 @@ export const DescribePipelineRunCommand = class {
     try {
       const response = await pipelines.describePipelineRun(options.project || profile.project, profile.token, runId);
       if (response.success) {
-        if (options.report && !options.json) {
+        if (options.json) {
+          getFilteredOutput(response, options);
+        } else {
+          // Print table view of Pipeline Run
           const result = filterObject(response, getQueryOptions(options));
           const tableSpec = [
             { column: 'Block Name', field: 'name', width: 40 },
@@ -186,12 +189,12 @@ export const DescribePipelineRunCommand = class {
           ];
           const blocks = this.extractBlocksFromRun(result);
           const elapsed = result?.end ? dayjs(result.end).diff(dayjs(result.start)) : 'N/A';
+          const logsAvailable = Object.prototype.hasOwnProperty.call(result, 'response') ? 'Yes' : 'No';
           printSuccess(`Status: ${result?.status}`);
-          printSuccess(`Elapsed Time (ms): ${elapsed}\n`);
+          printSuccess(`Elapsed Time (ms): ${elapsed}`);
+          printSuccess(`Logs Available: ${logsAvailable}`);
           printSuccess('Details:');
           printTable(tableSpec, _.sortBy(blocks, ['start', 'end']));
-        } else {
-            getFilteredOutput(response, options);
         }
       } else {
         printError(`Failed to desribe pipeline run ${runId}: ${response.message}`, options);

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -33,7 +33,9 @@ export const ListPipelineCommand = class {
     debug('%s.executeListPipelines()', profile.name);
     const pipelines = new Pipelines(profile.url);
     try {
-      const response = await pipelines.listPipelines(options.project || profile.project, profile.token, options.filter, options.limit, options.skip, options.sort);
+      const filteringByRepo = options.repo && !options.filter;
+      const filter = filteringByRepo ? JSON.stringify({ gitRepoName: options.repo }) : options.filter;
+      const response = await pipelines.listPipelines(options.project || profile.project, profile.token, filter, options.limit, options.skip, options.sort);
       if (response.success) {
         const result = response.pipelines;
         if (options.json) {

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -16,6 +16,7 @@ import {
     getQueryOptions,
     printSuccess,
     printTable,
+    printWarning,
 } from './utils.js';
 
 const debug = debugSetup('cortex:cli');
@@ -35,6 +36,9 @@ export const ListPipelineCommand = class {
     try {
       const filteringByRepo = options.repo && !options.filter;
       const filter = filteringByRepo ? JSON.stringify({ gitRepoName: options.repo }) : options.filter;
+      if (options.repo && options.filter) {
+        printWarning('WARNING: --repo and --filter options are incompatible! The --filter option will be used', options);
+      }
       const response = await pipelines.listPipelines(options.project || profile.project, profile.token, filter, options.limit, options.skip, options.sort);
       if (response.success) {
         const result = response.pipelines;

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -108,7 +108,7 @@ export const RunPipelineCommand = class {
         // TODO: Should replacment of activationId -> runId be done at the API level ?
         response.runId = response?.runId || response?.activationId; // support runId and activationId
         delete response.activationId;
-        if (response.json) {
+        if (options.json) {
           getFilteredOutput(response, options);
         } else {
           printSuccess(`Pipeline Run Submitted!\n\nUse "cortex pipelines describe-run ${response.runId}" to inspect the Pipeline Run`);

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -140,6 +140,11 @@ export const DescribePipelineRunCommand = class {
     // NOTE: 'plan.states' & 'transits' should be equivalent, so try
     // extracting details of the Pipeline run from the corresponding
     // 'state'. Only consider Blocks to avoid confusion from input/output.
+    //
+    // TODO:: states & transits aren't necessarily equivalent when running an
+    // single Block in a Pipeline. However, BUG https://cognitivescale.atlassian.net/browse/FAB-6294
+    // makes it so the entire Pipeline is run. Once that is resolved, the CLI
+    // can be configured to accurately print the plan.
     const blocks = pipelineRun?.transits?.map((t) => {
       const state = this.getStateMatchingTransit(t, pipelineRun?.plan?.states);
       // Skills are equivalent to Blocks, so it's clearer to rename the

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -105,11 +105,19 @@ export const RunPipelineCommand = class {
     try {
       const response = await pipelines.runPipeline(options.project || profile.project, profile.token, pipelineName, gitRepoName, params, options);
       if (response.success) {
-        return getFilteredOutput(response, options);
+        // TODO: Should replacment of activationId -> runId be done at the API level ?
+        response.runId = response?.runId || response?.activationId; // support runId and activationId
+        delete response.activationId;
+        if (response.json) {
+          getFilteredOutput(response, options);
+        } else {
+          printSuccess(`Pipeline Run Submitted!\n\nUse "cortex pipelines describe-run ${response.runId}" to inspect the Pipeline Run`);
+        }
+        return;
       }
-      return printError(`Failed to run pipeline: ${response.status} ${response.message}`, options);
+      printError(`Failed to run pipeline: ${response.status} ${response.message}`, options);
     } catch (err) {
-      return printError(`Failed to run pipeline: ${err.status} ${err.message}`, options);
+      printError(`Failed to run pipeline: ${err.status} ${err.message}`, options);
     }
   }
 };

--- a/src/commands/pipelines.js
+++ b/src/commands/pipelines.js
@@ -93,17 +93,17 @@ export const RunPipelineCommand = class {
     debug('%s.executeRunPipeline(%s)', profile.name, pipelineName);
     let params = {};
     if (options.params) {
-        try {
-            params = parseObject(options.params, options);
-        } catch (e) {
-            printError(`Failed to parse params: ${options.params} Error: ${e}`, options);
-        }
+      try {
+        params = parseObject(options.params, options);
+      } catch (e) {
+        printError(`Failed to parse params: ${options.params}. Error: ${e}`, options);
+      }
     } else if (options.paramsFile) {
-        if (!fs.existsSync(options.paramsFile)) {
-            printError(`File does not exist at: ${options.paramsFile}`);
-        }
-        const paramsStr = fs.readFileSync(options.paramsFile);
-        params = parseObject(paramsStr, options);
+      if (!fs.existsSync(options.paramsFile)) {
+        printError(`File does not exist at: ${options.paramsFile}`, options);
+      }
+      const paramsStr = fs.readFileSync(options.paramsFile);
+      params = parseObject(paramsStr, options);
     }
     const pipelines = new Pipelines(profile.url);
     try {

--- a/test/pipelines.js
+++ b/test/pipelines.js
@@ -298,46 +298,48 @@ describe('Pipelines', () => {
       nock.isDone();
     });
 
-    xit('describe pipeline run', async () => {
-      const response = {
-        success: true,
-        agentName: 'toy-pipeline',
-        channelId: 'd9e97efc-c663-43e7-a435-2b85d6977d1c',
-        payload: {
+    describe('#describePipelineRun()', () => {
+      xit('describe pipeline run', async () => {
+        const response = {
+          success: true,
+          agentName: 'toy-pipeline',
+          channelId: 'd9e97efc-c663-43e7-a435-2b85d6977d1c',
+          payload: {
             config: '/app/conf/spark-conf-sensa-data-pipeline.json',
             app_command: [
-                '--var',
-                'key=value',
-                '--pipeline',
-                'claro_pipeline',
-                '--config',
-                'config_catalog.yml',
-                '.',
-                '--repo',
-                'git@github.com:CognitiveScale/sensa-data-pipelines.git',
-                '--block',
-                'someblock',
+              '--var',
+              'key=value',
+              '--pipeline',
+              'claro_pipeline',
+              '--config',
+              'config_catalog.yml',
+              '.',
+              '--repo',
+              'git@github.com:CognitiveScale/sensa-data-pipelines.git',
+              '--block',
+              'someblock',
             ],
-        },
-        projectId: 'mc-test',
-        requestId: '54ea4199-1590-46ca-b49d-2f2574ef5873',
-        serviceName: 'input',
-        sessionId: '54ea4199-1590-46ca-b49d-2f2574ef5873',
-        sync: false,
-        timestamp: 1696875227736,
-        token: 'eyJhbGciOiJxm_K3fAA',
-        username: 'cortex@example.com',
-        start: 1696875227868,
-        status: 'COMPLETE',
-        end: 1696875239664,
-        response: {},
-      };
-      nock(serverUrl).get(/\/fabric\/v4\/projects\/.*\/pipelines\/.*\/run\/.*/).query({ gitRepoName: 'repo1' }).reply(200, response);
-      await create().parseAsync(['node', 'pipelines', 'describe-run', 'pipeline1', 'repo1', 'd9e97efc-c663-43e7-a435-2b85d6977d1c', '--project', PROJECT]);
-      const errs = getErrorLines().join('');
-      // eslint-disable-next-line no-unused-expressions
-      chai.expect(errs).to.be.empty;
-      nock.isDone();
+          },
+          projectId: 'mc-test',
+          requestId: '54ea4199-1590-46ca-b49d-2f2574ef5873',
+          serviceName: 'input',
+          sessionId: '54ea4199-1590-46ca-b49d-2f2574ef5873',
+          sync: false,
+          timestamp: 1696875227736,
+          token: 'eyJhbGciOiJxm_K3fAA',
+          username: 'cortex@example.com',
+          start: 1696875227868,
+          status: 'COMPLETE',
+          end: 1696875239664,
+          response: {},
+        };
+        nock(serverUrl).get(/\/fabric\/v4\/projects\/.*\/pipelines\/.*\/run\/.*/).query({ gitRepoName: 'repo1' }).reply(200, response);
+        await create().parseAsync(['node', 'pipelines', 'describe-run', 'pipeline1', 'repo1', 'd9e97efc-c663-43e7-a435-2b85d6977d1c', '--project', PROJECT]);
+        const errs = getErrorLines().join('');
+        // eslint-disable-next-line no-unused-expressions
+        chai.expect(errs).to.be.empty;
+        nock.isDone();
+      });
     });
   });
 });


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [x] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [ ] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters 

----

1) Adds a shortcut flag `--repo` to list pipelines in a specific repo
```
 % cortex pipelines list --repo fab-6357
┌────────────────────┬────────────────────┬────────────────────┬──────────────────────┬──────────────────────┐
│ Name               │ Git Repo Name      │ SHA                │ Modified             │ Author               │
├────────────────────┼────────────────────┼────────────────────┼──────────────────────┼──────────────────────┤
│ ingest_lookup      │ fab-6357           │ 84c9d62            │ 3 days ago           │ cortex@example.com   │
└────────────────────┴────────────────────┴────────────────────┴──────────────────────┴──────────────────────┘
```
2)  There was logic for printing a *report* (Table) when describing a Pipeline. I modified this code slightly and used Pipeline Metadata from the activation to make this useful. **In my opinion, this is much more human friendly than printing the JSON for the Activation.** The `--json` flag is still available for printing the raw Activation.
```
$ cortex pipelines describe-run 5ff381cb-131b-46c2-866f-b1c9e3738619
Status: ERROR
Elapsed Time (ms): 433625
Logs Available: Yes
Details:
┌────────────────────────────────────────┬────────────────────────────────────────┬────────────────────┬────────────────────┬──────────────────────────────┐
│ Block Name                             │ Block Title                            │ Type               │ Status             │ Elapsed Time (ms)            │
├────────────────────────────────────────┼────────────────────────────────────────┼────────────────────┼────────────────────┼──────────────────────────────┤
│ copy_lookup_csv                        │ Copy Lookup CSV                        │ streaming          │ COMPLETE           │ 220216                       │
├────────────────────────────────────────┼────────────────────────────────────────┼────────────────────┼────────────────────┼──────────────────────────────┤
│ bronze                                 │ Create People Tables                   │ streaming          │ COMPLETE           │ 129304                       │
├────────────────────────────────────────┼────────────────────────────────────────┼────────────────────┼────────────────────┼──────────────────────────────┤
│ silver                                 │ Perform Merge                          │ dbt                │ ERROR              │ 105679                       │
└────────────────────────────────────────┴────────────────────────────────────────┴────────────────────┴────────────────────┴──────────────────────────────┘
```

:warning: **NOTE**: This works in showing the progress of the Pipeline, but the table only includes Blocks that have started to run (i.e. the # of rows in the table will increase as the Pipeline runs). It's unknown if this correctly shows Pipelines that run a single Block, but that is mostly its not possible, right now, due to https://cognitivescale.atlassian.net/browse/FAB-6294

3) Changes the output when submitting a Pipeline Run to print a message and adds a `--json` flag to keep the original output
```
% cortex pipelines run ingest_lookup fab-6357 --params-file ingest_lookup/payload.json
Pipeline Run Submitted!

Use "cortex pipelines describe-run c22e4af0-5916-491d-aed2-ea1301b39c5a" to inspect the Pipeline Run
```

```
 % cortex pipelines run ingest_lookup fab-6357 --params-file ingest_lookup/payload.json --json
{
  "success": true,
  "runId": "a9db4c4a-b2da-4832-bef1-be667423a423"
}
```