### PR TITLE
FAB-6043: Add ability to schedule Pipeline runs

### DIFF
--- a/bin/cortex-pipelines.js
+++ b/bin/cortex-pipelines.js
@@ -81,6 +81,8 @@ export function create() {
   .option('--params-file <paramsFile>', 'A file containing either JSON or YAML formatted params')
   .option('--commit <commit>', 'Git SHA for pipeline repository')
   .option('--block <block>', 'Block name to run a specific block')
+  .option('--scheduleName <name>', 'Identifier to uniquely identify a Pipelines schedule')
+  .option('--scheduleCron <cron>', 'Schedule Pipeline to run periodically using a cron schedule string for example: "0 0 * * *", @hourly, or @daily')
   .action(withCompatibilityCheck((pipelineName, gitRepoName, options) => {
     try {
       checkForEmptyArgs({ pipelineName, gitRepoName });

--- a/src/client/pipelines.js
+++ b/src/client/pipelines.js
@@ -54,6 +54,14 @@ export default class Pipelines {
       const endpoint = `${this.endpointV4(projectId)}/${encodeURIComponent(name)}/run`;
       debug('runPipeline(%s, %s) => %s', name, gitRepoName, endpoint);
       const { commit, block } = options;
+      const query = { };
+      if (options?.scheduleName) {
+        query.scheduleName = options.scheduleName;
+      }
+      if (options?.scheduleCron) {
+        query.scheduleCron = options.scheduleCron;
+      }
+
       const body = { gitRepoName, ...params };
       if (commit) {
         body.commit = commit;
@@ -65,6 +73,7 @@ export default class Pipelines {
         return await got.post(endpoint, {
           headers: defaultHeaders(token),
           json: body,
+          searchParams: query,
         }).json();
       } catch (err) {
         return constructError(err);

--- a/test/pipelines.js
+++ b/test/pipelines.js
@@ -250,6 +250,47 @@ describe('Pipelines', () => {
         nock.isDone();
       });
 
+      it('runs a Pipeline on a set schedule with a default schedule name', async () => {
+        const pipeline = 'pipeline-name';
+        const cron = '@hourly';
+        const response = {
+          success: true,
+          message: `Scheduled Pipeline "pipeline1" with task "project-pipeline1" using cron "${cron}"`,
+        };
+        nock(serverUrl)
+          .post(`/fabric/v4/projects/${PROJECT}/pipelines/${pipeline}/run`)
+          .query({ scheduleCron: cron })
+          .reply(200, response);
+        await create().parseAsync(['node', 'pipelines', 'run', pipeline, 'repo1', '--project', PROJECT, '--scheduleCron', cron]);
+        const output = getPrintedLines().join('');
+        const errs = getErrorLines().join('');
+        chai.expect(output).to.equal(response.message);
+        // eslint-disable-next-line no-unused-expressions
+        chai.expect(errs).to.be.empty;
+        nock.isDone();
+      });
+
+      it('runs a Pipeline on a set schedule with a user specified schedule name', async () => {
+        const pipeline = 'pipeline-name';
+        const name = 'my-custom-schedule';
+        const cron = '@hourly';
+        const response = {
+          success: true,
+          message: `Scheduled Pipeline "pipeline1" with task "${name}" using cron "${cron}"`,
+        };
+        nock(serverUrl)
+          .post(`/fabric/v4/projects/${PROJECT}/pipelines/${pipeline}/run`)
+          .query({ scheduleCron: cron, scheduleName: name })
+          .reply(200, response);
+        await create().parseAsync(['node', 'pipelines', 'run', pipeline, 'repo1', '--project', PROJECT, '--scheduleCron', cron, '--scheduleName', name]);
+        const output = getPrintedLines().join('');
+        const errs = getErrorLines().join('');
+        chai.expect(output).to.equal(response.message);
+        // eslint-disable-next-line no-unused-expressions
+        chai.expect(errs).to.be.empty;
+        nock.isDone();
+      });
+
       it('fails to run a Pipeline due to params-file not found', async () => {
         try {
           await create().parseAsync(['node', 'pipelines', 'run', 'pipeline1', 'repo1', '--project', PROJECT, '--params-file', '/tmp/not-found.json']);


### PR DESCRIPTION
# Checklist:
Please check you fulfill ALL of the relevant checkboxes
- [ ] Notified docs of any potential USER-facing changes
- [x] Added short description of the change - with relevant motivation and context. 
- [x] Branch has the ticket number in its name (along with a ticket summary)
- [x] Commented the code, particularly in hard-to-understand areas
- [x] Added tests that prove my fix is effective or that my feature works
- [x] Ran `npm test` and it passes
- [x] Changes generate no new warnings
- [x] Changes are backward compatible with older clusters

Adds `--scheduleCron` and `--scheduleName` options to the Pipeline run CLI command - behavior is identical to Agent scheduling. 

Related Issue: https://cognitivescale.atlassian.net/browse/FAB-6043